### PR TITLE
Fix: profile 조회로 토큰 유효성을 사전에 검증하는 구조

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import {ROUTES} from "@/constants/url";
 import {useColorScheme} from "@/hooks/use-color-scheme";
 import {useNotifications} from "@/hooks/use-notifications";
 import {useAuthStore} from "@/store/authStore";
+import {useProfile} from "@/hooks/queries/useUserQueries";
 import {BottomSheetModalProvider} from "@gorhom/bottom-sheet";
 import {
     DarkTheme,
@@ -23,36 +24,59 @@ SplashScreen.preventAutoHideAsync();
 
 const queryClient = new QueryClient();
 
-export default function RootLayout() {
+function RootLayoutNav() {
     useNotifications();
     const router = useRouter();
     const segments = useSegments();
     const {token, isInitialized} = useAuthStore();
 
-    const colorScheme = useColorScheme();
+    // 폰트 로딩
     const [fontsLoaded] = useFonts({
         "Pretendard-Regular": require("../assets/fonts/Pretendard-Regular.otf"),
         "Pretendard-Medium": require("../assets/fonts/Pretendard-Medium.otf"),
         "Pretendard-Bold": require("../assets/fonts/Pretendard-Bold.otf"),
     });
 
-    // 인증 상태에 따른 리다이렉트 처리 (중앙 집중화)
+    // 토큰이 있을 경우에만 서버 검증 수행
+    const { data: profile, isError, isLoading: isProfileLoading } = useProfile({
+        enabled: isInitialized && !!token,
+        retry: false, // 유효성 검사 실패 시 바로 로그인으로 보내기 위해 재시도 끔
+    });
+
+    // 앱 준비 완료 조건: 
+    // 1. 초기화 완료 AND 2. 폰트 로딩 완료 
+    // AND (3. 토큰이 없거나 OR 4. 토큰 검증이 끝났거나(로딩 종료))
+    const isAppReady = isInitialized && fontsLoaded && (!token || !isProfileLoading);
+
+    const colorScheme = useColorScheme();
+
+    // 인증 상태 및 검증 결과에 따른 리다이렉트 처리
     useEffect(() => {
-        if (!isInitialized || !fontsLoaded) return;
+        if (!isAppReady) return;
 
         const inAuthGroup = segments[0] === "(auth)";
 
-        if (!token && !inAuthGroup) {
+        if (!token) {
             // 토큰이 없는데 인증이 필요한 페이지에 있다면 로그인으로 이동
-            router.replace(ROUTES.LOGIN);
-        } else if (token && inAuthGroup) {
-            // 토큰이 있는데 로그인/회원가입 페이지에 있다면 메인으로 이동
-            router.replace(ROUTES.MAP);
+            if (!inAuthGroup) {
+                router.replace(ROUTES.LOGIN);
+            }
+        } else if (profile) {
+            // 토큰이 있고 검증도 성공했다면 메인으로 (로그인/회원가입 페이지에 있을 경우만)
+            if (inAuthGroup) {
+                router.replace(ROUTES.MAP);
+            }
+        } else if (isError) {
+            // 토큰은 있지만 검증에 실패한 경우 (401 등)
+            // 인터셉터에서 이미 토큰을 지웠을 수 있지만, 안전하게 한 번 더 체크하여 로그인으로 유도
+            if (!inAuthGroup) {
+                router.replace(ROUTES.LOGIN);
+            }
         }
-    }, [token, isInitialized, segments, fontsLoaded]);
+    }, [token, isAppReady, segments, profile, isError]);
 
-    // 초기화 중이거나 폰트 로딩 중이면 스플래시 화면 유지
-    if (!isInitialized || !fontsLoaded) {
+    // 초기화 중이면 스플래시 화면 유지
+    if (!isAppReady) {
         return null;
     }
 
@@ -60,37 +84,43 @@ export default function RootLayout() {
     SplashScreen.hideAsync();
 
     return (
+        <ThemeProvider
+            value={colorScheme === "dark" ? DarkTheme : DefaultTheme}
+        >
+            <Stack>
+                <Stack.Screen name="index" options={{headerShown: false}}/>
+                <Stack.Screen name="(auth)" options={{headerShown: false}}/>
+                <Stack.Screen name="(tabs)" options={{headerShown: false}}/>
+                <Stack.Screen name="loading" options={{headerShown: false}}/>
+                <Stack.Screen
+                    name="modal"
+                    options={{presentation: "modal", title: "Modal"}}
+                />
+                <Stack.Screen
+                    name="lost-item-detail"
+                    options={{headerShown: false}}
+                />
+                <Stack.Screen
+                    name="lost-item-register"
+                    options={{headerShown: false}}
+                />
+                <Stack.Screen
+                    name="chat-room"
+                    options={{headerShown: false}}
+                />
+            </Stack>
+            <StatusBar style="auto"/>
+        </ThemeProvider>
+    );
+}
+
+export default function RootLayout() {
+    return (
         <QueryClientProvider client={queryClient}>
             <GestureHandlerRootView style={{flex: 1}}>
                 <BottomSheetModalProvider>
                     <SafeAreaProvider>
-                        <ThemeProvider
-                            value={colorScheme === "dark" ? DarkTheme : DefaultTheme}
-                        >
-                            <Stack>
-                                <Stack.Screen name="index" options={{headerShown: false}}/>
-                                <Stack.Screen name="(auth)" options={{headerShown: false}}/>
-                                <Stack.Screen name="(tabs)" options={{headerShown: false}}/>
-                                <Stack.Screen name="loading" options={{headerShown: false}}/>
-                                <Stack.Screen
-                                    name="modal"
-                                    options={{presentation: "modal", title: "Modal"}}
-                                />
-                                <Stack.Screen
-                                    name="lost-item-detail"
-                                    options={{headerShown: false}}
-                                />
-                                <Stack.Screen
-                                    name="lost-item-register"
-                                    options={{headerShown: false}}
-                                />
-                                <Stack.Screen
-                                    name="chat-room"
-                                    options={{headerShown: false}}
-                                />
-                            </Stack>
-                            <StatusBar style="auto"/>
-                        </ThemeProvider>
+                        <RootLayoutNav />
                     </SafeAreaProvider>
                 </BottomSheetModalProvider>
             </GestureHandlerRootView>

--- a/hooks/queries/useUserQueries.ts
+++ b/hooks/queries/useUserQueries.ts
@@ -1,9 +1,11 @@
-import {useQuery} from '@tanstack/react-query';
+import {useQuery, UseQueryOptions} from '@tanstack/react-query';
 import {userService} from '@/api/services/user';
+import {UserProfile} from '@/api/types';
 
-export const useProfile = () => {
+export const useProfile = (options?: Partial<UseQueryOptions<UserProfile>>) => {
     return useQuery({
         queryKey: ['userProfile'],
         queryFn: () => userService.getProfile(),
+        ...options,
     });
 };


### PR DESCRIPTION
토큰 유효성을 사전에 검증하는 구조로 리팩토링을 완료했습니다.
사용자가 만료된 토큰을 가지고 앱을 켰을 때, 메인 화면을 보지 못하고 스플래시 화면에서 즉시 로그인 화면으로 이동하게 됩니다.

**주요 변경 사항**

1. hooks/queries/useUserQueries.ts 수정:  useProfile 훅이 options를 인자로 받을 수 있도록 수정하여, 특정 조건(예: 토큰이 있을 때만)에서만 실행되도록 제어할 수 있게 했습니다.
2. app/_layout.tsx 대규모 리팩토링: 구조 분리: Provider 설정(RootLayout)과 실제 내비게이션 로직(RootLayoutNav)을 분리하여, 내비게이션 로직 내에서 React Query 훅(useProfile)을 사용할 수 있도록 했습니다.
3. 사전 검증 로직 추가: 토큰이 로컬에 존재하면 useProfile을 즉시 호출합니다.이때 retry: false 설정을 통해 만료된 토큰으로 인한 불필요한 재시도를 방지했습니다.(isAppReady 조건 강화)

**기대 효과**

1. UX 개선: 만료된 토큰 사용자가 메인 화면에 들어갔다가 순식간에 튕겨 나가는 "Bouncing" 현상이 완전히 제거되었습니다.
2. 안정성: 메인 화면 진입 시점에 이미 토큰의 유효성이 확인되었으므로, 이후 발생하는 API 요청들이 더 안전하게 수행됩니다.
3. 확장성: 추후 Refresh Token을 도입할 때, Axios 인터셉터만 수정하면 이 사전 검증 단계에서 자동으로 토큰 갱신이 이루어지므로 구조 변경 없이 기능을 추가할 수 있습니다.

  이제 앱을 실행하면 백그라운드에서 조용히 검증을 마친 뒤, 가야 할 화면으로 부드럽게 이동하게 됩니다.