### PR TITLE
로그인 이슈 버그 픽스 

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -30,6 +30,13 @@ axiosInstance.interceptors.request.use(
 axiosInstance.interceptors.response.use(
     (response) => response,
     async (error) => {
+        if (__DEV__) {
+            console.error(
+                `[API Error] ${error.config?.method?.toUpperCase()} ${error.config?.url}`,
+                error.response?.status,
+                error.response?.data,
+            );
+        }
         if (error.response?.status === 401) {
             // 401 발생 시 스토어 초기화 (자동 로그아웃 유도)
             useAuthStore.getState().clearToken();

--- a/api/services/timetable.ts
+++ b/api/services/timetable.ts
@@ -22,7 +22,9 @@ export const timetableService = {
                 sort: 'courseName,asc'
             }
         });
-        return response.data.data;
+        const page_data = response.data.data;
+        page_data.content = page_data.content.map(c => ({ ...c, schedules: c.schedules ?? [] }));
+        return page_data;
     },
 
     getPrimaryTimetable: async () => {
@@ -42,7 +44,7 @@ export const timetableService = {
 
     getTimetableDetail: async (id: number) => {
         const response = await axiosInstance.get<ApiResponse<Course[]>>(`${TIMETABLES_URL}/${id}`);
-        return response.data.data;
+        return (response.data.data ?? []).map(c => ({ ...c, schedules: c.schedules ?? [] }));
     },
 
     syncTimetable: async (id: number, data: SyncTimetableRequest) => {

--- a/api/services/timetable.ts
+++ b/api/services/timetable.ts
@@ -25,6 +25,11 @@ export const timetableService = {
         return response.data.data;
     },
 
+    getPrimaryTimetable: async () => {
+        const response = await axiosInstance.get<ApiResponse<TimetableSummary>>(`${TIMETABLES_URL}/primary`);
+        return response.data.data;
+    },
+
     getAllTimetables: async () => {
         const response = await axiosInstance.get<ApiResponse<TimetableSummary[]>>(`${TIMETABLES_URL}/mine`);
         return response.data.data;

--- a/api/types.ts
+++ b/api/types.ts
@@ -87,16 +87,20 @@ export interface PageResponse<T> {
 // --- Timetable & Course ---
 export type DayOfWeek = 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN';
 
-export interface Course {
-    courseId: number;
-    courseName: string;
+export interface CourseSchedule {
     dayOfWeek: DayOfWeek;
     startTime: string; // HH:mm:ss
     endTime: string;   // HH:mm:ss
+}
+
+export interface Course {
+    courseId: number;
+    courseName: string;
     roomName: string;
     buildingName: string;
     buildingCode: string;
     color?: string;
+    schedules: CourseSchedule[];
 }
 
 export interface TimetableSummary {

--- a/app/(auth)/signup/profile.tsx
+++ b/app/(auth)/signup/profile.tsx
@@ -3,13 +3,13 @@ import { fonts } from "@/constants/typography";
 import { ROUTES } from "@/constants/url";
 import { useSignup } from "@/hooks/mutations/useAuthMutations";
 import { useCheckNickname } from "@/hooks/queries/useAuthQueries";
+import { useAuthStore } from "@/store/authStore";
 import {
   BottomSheetBackdrop,
   BottomSheetFlatList,
   BottomSheetModal,
   BottomSheetTextInput,
 } from "@gorhom/bottom-sheet";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
 import {
@@ -119,11 +119,9 @@ export default function ProfilePage() {
         onSuccess: async (result) => {
           if (result.success) {
             if (result.data.access_token) {
-              await AsyncStorage.setItem("token", result.data.access_token);
+              useAuthStore.getState().setToken(result.data.access_token);
             }
-            requestAnimationFrame(() => {
-              router.replace(ROUTES.MAP);
-            });
+            router.replace(ROUTES.MAP);
           } else {
             setErrors({ nickname: result.error || "회원가입에 실패했습니다." });
           }

--- a/app/(tabs)/timetable.tsx
+++ b/app/(tabs)/timetable.tsx
@@ -37,9 +37,11 @@ const BG_TO_COLOR: Record<string, ColorSet> =
   Object.fromEntries(COLOR_PALETTE.map(c => [c.bg, c]));
 
 function assignColor(course: Course, allCourses: Course[]): string {
+  const courseDays = new Set(course.schedules.map(s => s.dayOfWeek));
   const usedOnSameDay = new Set(
     allCourses
-      .filter(c => c.dayOfWeek === course.dayOfWeek && c.courseId !== course.courseId && c.color)
+      .filter(c => c.courseId !== course.courseId && c.color &&
+        c.schedules.some(s => courseDays.has(s.dayOfWeek)))
       .map(c => c.color!)
   );
   const available = COLOR_PALETTE.find(p => !usedOnSameDay.has(p.bg));
@@ -128,10 +130,12 @@ export default function TimetableScreen() {
   }, [savedCourses, draftCourse]);
 
   const endHour = useMemo(() => {
-    const last = displayData.reduce((max, cls) => {
-      const h = parseInt(cls.endTime.split(':')[0], 10);
-      return h > max ? h : max;
-    }, DEFAULT_END_HOUR);
+    const last = displayData.reduce((max, cls) =>
+      cls.schedules.reduce((m, s) => {
+        const h = parseInt(s.endTime.split(':')[0], 10);
+        return h > m ? h : m;
+      }, max)
+    , DEFAULT_END_HOUR);
     return last < DEFAULT_END_HOUR ? DEFAULT_END_HOUR : last + 1;
   }, [displayData]);
 
@@ -333,15 +337,19 @@ export default function TimetableScreen() {
                         }}
                       />
                     ))}
-                    {displayData.filter(c => c.dayOfWeek === key).map((cls) => {
+                    {displayData.flatMap(cls =>
+                      cls.schedules
+                        .filter(s => s.dayOfWeek === key)
+                        .map(s => ({ cls, schedule: s }))
+                    ).map(({ cls, schedule }) => {
                       const isDraft = draftCourse?.courseId === cls.courseId;
-                      const { top, height } = getPosition(cls.startTime, cls.endTime);
+                      const { top, height } = getPosition(schedule.startTime, schedule.endTime);
                       const color = isDraft
                         ? { bg: '#F3F4F6', text: '#9CA3AF', border: '#E5E7EB' }
                         : (cls.color && BG_TO_COLOR[cls.color]) ? BG_TO_COLOR[cls.color] : COLOR_PALETTE[0];
                       return (
                         <TouchableOpacity
-                          key={cls.courseId}
+                          key={`${cls.courseId}-${schedule.dayOfWeek}`}
                           onPress={() => { if (!isDraft) setSelectedClass(cls); }}
                           activeOpacity={isDraft ? 1 : 0.8}
                           style={{
@@ -456,8 +464,9 @@ export default function TimetableScreen() {
               <View className="flex-row items-center" style={{ gap: 12 }}>
                 <Clock size={16} color="#9CA3AF" />
                 <Text className="text-sm text-gray-700">
-                  {DAYS.find(d => d.key === selectedClass.dayOfWeek)?.label}요일{' '}
-                  {selectedClass.startTime.substring(0, 5)} - {selectedClass.endTime.substring(0, 5)}
+                  {selectedClass.schedules.map(s =>
+                    `${DAYS.find(d => d.key === s.dayOfWeek)?.label}요일 ${s.startTime.substring(0, 5)}-${s.endTime.substring(0, 5)}`
+                  ).join(' / ')}
                 </Text>
               </View>
               <View className="flex-row items-center" style={{ gap: 12 }}>
@@ -502,8 +511,9 @@ export default function TimetableScreen() {
               <View className="flex-1">
                 <Text className="text-base font-bold text-gray-900">{draftCourse.courseName}</Text>
                 <Text className="text-sm text-gray-400 mt-0.5">
-                  {DAYS.find(d => d.key === draftCourse.dayOfWeek)?.label}요일{' '}
-                  {draftCourse.startTime.substring(0, 5)} - {draftCourse.endTime.substring(0, 5)} · {draftCourse.roomName}
+                  {draftCourse.schedules.map(s =>
+                    `${DAYS.find(d => d.key === s.dayOfWeek)?.label}요일 ${s.startTime.substring(0, 5)}-${s.endTime.substring(0, 5)}`
+                  ).join(' / ')} · {draftCourse.roomName}
                 </Text>
               </View>
             </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,7 +20,7 @@ import { useFonts } from "expo-font";
 import { Stack, useRouter, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import "react-native-reanimated";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -74,8 +74,16 @@ function RootLayoutNav() {
     // 앱 준비 완료 조건:
     // 1. 초기화 완료 AND 2. 폰트 로딩 완료
     // AND (3. 토큰이 없거나 OR 4. 토큰 검증이 끝났거나(로딩 종료))
-    const isAppReady =
-        isInitialized && fontsLoaded && (!token || !isProfileLoading);
+    const [isAppReady, setIsAppReady] = useState(false);
+
+    useEffect(() => {
+        if (!isAppReady) {
+            const ready = isInitialized && fontsLoaded && (!token || !isProfileLoading);
+            if (ready) {
+                setIsAppReady(true);
+            }
+        }
+    }, [isInitialized, fontsLoaded, token, isProfileLoading, isAppReady]);
 
     const colorScheme = useColorScheme();
 

--- a/components/CourseSearchModal.tsx
+++ b/components/CourseSearchModal.tsx
@@ -36,14 +36,18 @@ function isDuplicate(cls: Course, existing: Course[]) {
 }
 
 function isTimeOverlap(cls: Course, existing: Course[]) {
-  const clsStart = timeToMinutes(cls.startTime);
-  const clsEnd = timeToMinutes(cls.endTime);
-  return existing.some((e) => {
-    if (e.dayOfWeek !== cls.dayOfWeek) return false;
-    const eStart = timeToMinutes(e.startTime);
-    const eEnd = timeToMinutes(e.endTime);
-    return Math.max(clsStart, eStart) < Math.min(clsEnd, eEnd);
-  });
+  return existing.some((e) =>
+    cls.schedules.some(clsSlot =>
+      e.schedules.some(eSlot => {
+        if (eSlot.dayOfWeek !== clsSlot.dayOfWeek) return false;
+        const clsStart = timeToMinutes(clsSlot.startTime);
+        const clsEnd = timeToMinutes(clsSlot.endTime);
+        const eStart = timeToMinutes(eSlot.startTime);
+        const eEnd = timeToMinutes(eSlot.endTime);
+        return Math.max(clsStart, eStart) < Math.min(clsEnd, eEnd);
+      })
+    )
+  );
 }
 
 export interface CourseSearchModalProps {
@@ -93,7 +97,7 @@ export default function CourseSearchModal({
     };
   }, []);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
     useSearchCourses(year, semester, debouncedKeyword);
 
   const allCourses = useMemo(() => {
@@ -149,7 +153,7 @@ export default function CourseSearchModal({
               {item.courseName}
             </Text>
             <Text className="text-xs text-gray-400 mt-0.5" numberOfLines={1}>
-              {DAY_LABELS[item.dayOfWeek]} {item.startTime.substring(0, 5)}-{item.endTime.substring(0, 5)} · {item.roomName}
+              {item.schedules.map(s => `${DAY_LABELS[s.dayOfWeek]} ${s.startTime.substring(0, 5)}-${s.endTime.substring(0, 5)}`).join(' / ')} · {item.roomName}
             </Text>
           </View>
         </View>
@@ -225,6 +229,11 @@ export default function CourseSearchModal({
                   <>
                     <Search size={28} color="#D1D5DB" />
                     <Text className="text-sm text-gray-400 mt-2">강의명을 입력하면 자동으로 검색됩니다</Text>
+                  </>
+                ) : isError ? (
+                  <>
+                    <AlertCircle size={28} color="#FCA5A5" />
+                    <Text className="text-sm text-red-400 mt-2">강의 목록을 불러오지 못했습니다</Text>
                   </>
                 ) : (
                   <>

--- a/hooks/queries/useTimetableQueries.ts
+++ b/hooks/queries/useTimetableQueries.ts
@@ -4,8 +4,17 @@ import {timetableService} from '@/api/services/timetable';
 export const timetableKeys = {
     all: ['timetables'] as const,
     allList: () => [...timetableKeys.all, 'list'] as const,
+    primary: () => [...timetableKeys.all, 'primary'] as const,
     detail: (id: number) => [...timetableKeys.all, 'detail', id] as const,
     courses: (year: number, semester: number, keyword: string) => ['courses', year, semester, keyword] as const,
+};
+
+export const usePrimaryTimetable = () => {
+    return useQuery({
+        queryKey: timetableKeys.primary(),
+        queryFn: () => timetableService.getPrimaryTimetable(),
+        staleTime: 0,
+    });
 };
 
 // 서버에서 전체 시간표 목록을 항상 새로 조회 (캐시 없음)


### PR DESCRIPTION
  1. app/_layout.tsx (로그인 멈춤 해결):
       * 기존에는 로그인 성공 직후 새로운 토큰이 생기면 사용자 프로필을 불러오는 동안 앱 준비 상태(isAppReady)가 일시적으로 false로 돌아갔습니다.
       * 이로 인해 네비게이션 스택(<Stack>) 전체가 언마운트되면서 로그인 화면에서 메인 지도로 넘겨주는 명령(router.replace)이 유실되는 문제가 있었습니다.
       * isAppReady를 상태(useState)로 관리하여, 한 번 로딩이 완료된 후에는 다시 로딩 화면으로 돌아가지 않도록 수정했습니다. 이제 로그인 후에도 화면 전환이 끊김 없이 부드럽게 진행됩니다.

   2. app/(auth)/signup/profile.tsx (회원가입 후 리다이렉트 해결):
       * 회원가입 완료 시 토큰을 useAuthStore가 아닌 일반 AsyncStorage에 직접 저장하고 있었습니다.
       * 이 때문에 앱의 전체 인증 관리 로직이 토큰을 인식하지 못해, 지도로 이동하려 해도 다시 로그인 창으로 튕겨 나가는 현상이 발생했습니다.
       * 로그인 페이지와 동일하게 전역 스토어(useAuthStore)를 사용하도록 수정하여, 회원가입 완료 즉시 인증 상태가 반영되어 지도로 정상 이동하게 했습니다