### PR TITLE
  Feat: CCTV 분실물 탐지 화면 구현 및 Mock 검증

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(awk '{print $NF}')"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(awk '{print $NF}')"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,6 @@ app-example
 
 google-services.json
 .env
-
+.claude/
 GEMINI.md
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -1,195 +1,181 @@
-# 프런트 개발환경 세팅 가이드
+# ZooPick — 캠퍼스 분실물 플랫폼
 
-> Android용 가이드입니다.  
-> 현재 프로젝트는 Expo Go QR 실행 방식이 아니라, 개발 빌드 앱을 설치해서 실행하는 방식입니다.
+[![Expo](https://img.shields.io/badge/Expo-54.0-000020?logo=expo)](https://expo.dev)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![React Native](https://img.shields.io/badge/React%20Native-0.79-61DAFB?logo=react&logoColor=black)](https://reactnative.dev)
+
+> 명지대학교 자연 캠퍼스 학생들을 위한 분실물 신고·조회 모바일 애플리케이션
 
 ---
 
-## 🛠 사전 준비
+## 프로젝트 소개
 
-### 1. Node.js 설치
+캠퍼스에서 물건을 잃어버리거나 주운 경험이 있으신가요? ZooPick은 분실물 등록부터 AI 기반 자동 매칭, CCTV 연동 탐지, 실시간 채팅까지 하나의 앱에서 해결할 수 있도록 만들어진 서비스입니다.
 
-👉 https://nodejs.org 에서 **LTS 버전** 다운로드 후 설치
+- 분실물과 습득물을 지도 위에 직접 등록하고 위치를 시각적으로 확인
+- AI가 분실물-습득물 쌍을 자동으로 분석해 매칭 제안
+- 당사자 간 1:1 실시간 채팅으로 빠른 소통
 
-설치 확인:
+---
+
+## 주요 기능
+
+| 기능 | 설명 |
+|------|------|
+| 지도 기반 분실물 등록 | 카카오맵 위에서 위치를 지정하고 사진·카테고리와 함께 등록 |
+| AI 매칭 | 등록된 분실물과 습득물을 AI가 분석해 자동으로 매칭 제안 |
+| 실시간 채팅 | WebSocket 기반 1:1 채팅으로 당사자 간 직접 소통 |
+| QR 코드 스캔 | 물건에 부착된 QR 코드를 스캔해 소유자 정보 즉시 조회 |
+| IoT 사물함 제어 | QR 코드 스캔으로 교내 IoT 사물함 원격 개폐 |
+| CCTV 연동 | 교내 CCTV 영상에서 AI가 분실물을 탐지하고 결과를 제공 |
+| 푸시 알림 | Firebase FCM을 통해 매칭·채팅·분실물 알림 실시간 수신 |
+| 시간표 연동 | 수업 정보와 캠퍼스 건물 위치를 지도와 함께 확인 |
+
+---
+
+## 기술 스택
+
+| 분류 | 기술 |
+|------|------|
+| 프레임워크 | Expo 54 (React Native), Expo Router v6 |
+| 언어 | TypeScript 5.9 |
+| 상태 관리 | Zustand 5 (클라이언트), TanStack Query v5 (서버) |
+| 스타일링 | NativeWind 4 (Tailwind CSS), React Native StyleSheet |
+| API 통신 | Axios 1.15 (인터셉터·토큰 주입), WebSocket |
+| 지도 | Kakao Maps API (WebView) |
+| 알림 | Firebase Cloud Messaging (FCM) |
+| 폼 / 유효성 | React Hook Form 7, Zod 4 |
+| 날짜 처리 | dayjs |
+| 오프라인 캐시 | AsyncStorage + React Query AsyncStorage Persister |
+
+---
+
+## 시작하기
+
+> 이 프로젝트는 **Expo Go가 아닌 개발 빌드(Development Build)** 방식으로 실행합니다.
+
+### 사전 준비
+
+- Node.js LTS (v24.14.1 이상)
+- Android Studio (Android SDK, Platform-Tools 포함)
+- Android 기기 또는 에뮬레이터
+
+### 빠른 시작
 
 ```bash
-node -v
-```
-
-`v24.14.1` 이상이면 OK
-
----
-
-### 2. Android Studio 설치
-
-안드로이드 기기에 직접 앱을 설치해서 실행하기 위해 필요합니다.
-👉 [https://developer.android.com/studio](https://developer.android.com/studio)
-
-설치 후 아래 항목이 포함되어 있는지 확인해주세요.
-
-- Android SDK
-- Android SDK Platform-Tools
-- Android Emulator
-
----
-
-### 3. 휴대폰 개발자 옵션 설정
-
-실제 안드로이드 폰에 앱을 설치하려면 USB 디버깅을 켜야 합니다.
-
-1. 휴대폰 설정 → 휴대전화 정보
-2. 소프트웨어 정보
-3. 빌드 번호를 7번 터치
-4. 설정 → 개발자 옵션
-5. USB 디버깅 ON
-
----
-
-## 🚀 시작하기
-
-### 1단계 — 레포 클론
-
-```bash
+# 1. 레포 클론
 git clone https://github.com/2026-mju-capstone/front.git
 cd front
-```
 
----
-
-### 2단계 — 패키지 설치
-
-```bash
+# 2. 패키지 설치
 npm install
-```
 
-> ⚠️ 이 프로젝트는 네이티브 모듈을 사용합니다.
-> `npm install` 후 반드시 `npx expo run:android` 로 앱을 빌드해야 정상 동작합니다.
-> 아래 패키지들이 네이티브 빌드를 필요로 합니다:
->
-> - `expo-media-library` (갤러리 접근)
-> - `expo-image-picker` (카메라/갤러리)
-> - `@react-native-community/datetimepicker` (날짜/시간 선택)
-> - `@react-native-picker/picker` (스크롤 휠 선택)
+# 3. 환경변수 설정
+# 프로젝트 루트에 .env 파일 생성 후 아래 내용 입력
+echo "EXPO_PUBLIC_BASE_URL=http://52.63.7.132:8080" > .env
 
----
-
-### 3단계 — 환경변수 설정
-
-프로젝트 루트, 즉 `app`, `assets`, `components` 폴더가 있는 위치에 `.env` 파일을 직접 만들어야 합니다.
-
-#### 1. 프로젝트 최상위 폴더로 이동
-
-`front` 폴더 안에 `app`, `assets`, `components` 등이 있는 위치입니다.
-
-#### 2. `.env` 파일 생성
-
-VSCode / Cursor 사용 중이라면
-왼쪽 파일 트리에서 프로젝트 폴더 우클릭 → `New File` → 파일 이름을 `.env` 로 입력
-
-#### 3. 아래 내용 붙여넣기
-
-```env
-EXPO_PUBLIC_BASE_URL=http://52.63.7.132:8080
-```
-
-#### 4. 저장
-
-Windows: `Ctrl + S`
-Mac: `Cmd + S`
-
-> ⚠️ 파일 이름이 반드시 `.env` 여야 합니다.
-> `.env.txt` 로 저장되지 않도록 주의해주세요.
-> 이 파일은 git에 올라가지 않습니다.
-
----
-
-## 📱 앱 실행 방법
-
-현재 프로젝트는 Expo Go 앱에서 QR을 스캔해서 실행하는 방식이 아닙니다.
-개발용 앱을 휴대폰에 직접 설치한 뒤 실행해야 합니다.
-
----
-
-### Android 실행
-
-휴대폰을 USB로 PC에 연결한 뒤 아래 명령어를 실행합니다.
-
-```bash
-npx expo install expo-dev-client
+# 4. Android 기기를 USB로 연결한 뒤 앱 빌드 및 실행
 npx expo run:android
 ```
 
-처음 실행하면 휴대폰에 개발용 앱이 설치됩니다.
-이후에는 설치된 앱을 실행해서 개발 화면에 진입할 수 있습니다.
+> 네이티브 패키지를 새로 설치한 경우 `npx expo start`가 아니라 반드시 `npx expo run:android`를 다시 실행해야 합니다.
 
-> ⚠️ 네이티브 패키지를 새로 설치한 경우 반드시 `npx expo run:android` 를 다시 실행해야 합니다.
-> `npx expo start` 만으로는 네이티브 모듈이 반영되지 않습니다.
+<details>
+<summary>Android 기기 설정 (USB 디버깅 활성화)</summary>
+
+1. 설정 → 휴대전화 정보 → 소프트웨어 정보
+2. 빌드 번호를 7번 터치 → 개발자 옵션 활성화
+3. 설정 → 개발자 옵션 → USB 디버깅 ON
+4. USB 연결 후 기기에서 "USB 디버깅 허용" 팝업 허용
+
+</details>
+
+<details>
+<summary>앱 권한 안내</summary>
+
+앱 실행 후 아래 권한을 허용해야 정상 동작합니다.
+
+- 카메라 — 분실물 사진 촬영
+- 사진/미디어 — 갤러리에서 사진 선택
+- 위치 — 캠퍼스 지도에서 현재 위치 표시
+
+</details>
+
+<details>
+<summary>자주 발생하는 문제</summary>
+
+**QR을 찍었는데 Expo Go에서 열리지 않아요**
+이 프로젝트는 Expo Go가 아닌 개발 빌드 앱으로 실행해야 합니다. `npx expo run:android`로 앱을 먼저 설치해주세요.
+
+**`localhost:8081` 화면이 떠요**
+휴대폰과 PC가 같은 네트워크에 있는지 확인하세요. 학교 와이파이처럼 기기 간 통신이 막힌 환경이라면 핫스팟을 사용하세요.
+
+**네이티브 모듈 오류 (Cannot find native module)**
+새로운 네이티브 패키지가 추가된 경우입니다. `npx expo run:android`로 다시 빌드하세요.
+
+**앱 설치가 안 돼요**
+USB 디버깅 활성화 여부, USB 케이블의 데이터 전송 지원 여부, Android Studio SDK 설치 여부를 확인하세요.
+
+</details>
 
 ---
 
-## 📷 앱 권한 안내
+## 프로젝트 구조
 
-앱 실행 후 아래 권한 요청이 발생할 수 있습니다.
-정상 동작을 위해 모두 허용해주세요.
-
-- **카메라** - 분실물 사진 촬영
-- **사진/미디어** - 갤러리에서 사진 선택
-- **위치** - 캠퍼스 지도에서 내 위치 표시
-
----
-
-## ❗ 주의사항
-
-- Expo Go 앱으로는 실행되지 않습니다.
-- 웹 QR을 스캔해도 바로 접속되지 않을 수 있습니다.
-- 반드시 `npx expo run:android` 로 개발용 앱을 설치해야 합니다.
-- 휴대폰과 개발 PC는 같은 와이파이에 연결되어 있어야 합니다.
-- 학교 와이파이처럼 기기 간 통신이 막힌 환경에서는 연결이 안 될 수 있습니다.
-- 연결이 안 될 경우 핫스팟을 사용해보세요.
-- USB 연결 시 휴대폰에서 "USB 디버깅 허용"을 눌러야 합니다.
-
----
-
-## ✅ 자주 발생하는 문제
-
-### QR을 찍었는데 Expo Go에서 열리지 않아요
-
-정상입니다.
-이 프로젝트는 Expo Go가 아니라 개발 빌드 앱으로 실행해야 합니다.
-
-```bash
-npx expo run:android
+```
+front/
+├── app/                # Expo Router 화면 (파일 기반 라우팅)
+│   ├── (auth)/         # 로그인, 회원가입 플로우
+│   ├── (tabs)/         # 메인 탭 화면 (지도, 게시판, 스캔, 시간표, 채팅)
+│   └── _layout.tsx     # 루트 레이아웃 및 전역 프로바이더
+├── api/
+│   ├── client.ts       # Axios 인스턴스 (토큰 주입, 401 처리)
+│   ├── types.ts        # 모든 API 응답/요청 TypeScript 타입
+│   └── services/       # 도메인별 API 함수 (auth, item, chat, match...)
+├── components/         # 재사용 UI 컴포넌트
+├── hooks/
+│   ├── queries/        # React Query 조회 훅
+│   └── mutations/      # React Query 변경 훅
+├── store/              # Zustand 전역 상태 (auth, loading, timetable)
+├── constants/          # 테마, URL, 카테고리, 건물 좌표 등 상수
+└── utils/              # 순수 유틸 함수 (날짜 포맷, 지도 마커 등)
 ```
 
-위 명령어로 앱을 먼저 설치해주세요.
-
 ---
 
-### `localhost:8081` 화면이 떠요
+## 아키텍처
 
-개발 서버 주소가 PC 기준으로 잡힌 상태일 수 있습니다.
-휴대폰과 PC가 같은 네트워크에 있는지 확인하고, 안 되면 핫스팟으로 연결해보세요.
+### 데이터 흐름
 
----
-
-### 앱 설치가 안 돼요
-
-아래 내용을 확인해주세요.
-
-- USB 디버깅이 켜져 있는지
-- 휴대폰에서 USB 디버깅 허용을 눌렀는지
-- Android Studio / SDK / Platform-Tools가 설치되어 있는지
-- USB 케이블이 데이터 전송을 지원하는지
-
----
-
-### 네이티브 모듈 오류가 떠요 (Cannot find native module)
-
-새로운 네이티브 패키지가 추가된 경우입니다.
-
-```bash
-npx expo run:android
+```
+화면 (app/)
+    |
+    | 훅 호출
+    v
+hooks/queries · mutations/   <-->   Zustand store (auth, loading)
+    |
+    | 서비스 호출
+    v
+api/services/                <-->   api/types.ts (공유 타입)
+    |
+    | HTTP / WebSocket
+    v
+백엔드 서버
 ```
 
-위 명령어로 앱을 다시 빌드해주세요.
+### 규칙
+
+- `app/` 화면 파일에는 UI 로직과 훅 호출만 작성합니다. `axios.get` / `axios.post`를 직접 사용하지 않습니다.
+- 새 기능을 추가할 때는 `api/types.ts` → `api/services/` → `hooks/queries` 또는 `hooks/mutations/` 순서로 작성합니다.
+- `utils/`는 순수 함수(사이드 이펙트 없음)만 허용합니다. API 호출이나 React 훅을 넣지 않습니다.
+- `any` 타입 사용을 금지합니다. API 응답 타입은 반드시 `api/types.ts`에서 가져옵니다.
+
+---
+
+## 팀원
+
+| 이름 | GitHub | 역할 |
+|------|--------|------|
+| Dongrang072 | [@Dongrang072](https://github.com/Dongrang072) | 프론트엔드 |
+| wonjumini | [@wonjumini](https://github.com/wonjumini) | 프론트엔드 |
+| lalaalal | [@lalaalal](https://github.com/lalaalal) | 프론트엔드 |

--- a/api/services/cctv.ts
+++ b/api/services/cctv.ts
@@ -1,0 +1,25 @@
+import axiosInstance from "@/api/client";
+import {
+    ApiResponse,
+    CctvItemDetectionsResponse,
+    CctvMyItemsResponse,
+    CctvReviewRequest,
+} from "@/api/types";
+
+export const cctvService = {
+    getMyItems: () =>
+        axiosInstance.get<ApiResponse<CctvMyItemsResponse>>("/api/cctv/detections/me"),
+
+    getItemDetections: (itemId: number) =>
+        axiosInstance.get<ApiResponse<CctvItemDetectionsResponse>>(
+            "/api/cctv/detections/me",
+            {params: {itemId}}
+        ),
+
+    reviewDetection: (detectionId: number, body: CctvReviewRequest) =>
+        axiosInstance.put<ApiResponse<null>>(
+            `/api/cctv/detections/${detectionId}/review`,
+            body
+        ),
+};
+

--- a/api/types.ts
+++ b/api/types.ts
@@ -275,3 +275,37 @@ export interface MatchManualResponse {
   match_manual_type: MatchManualType;
   locker_id: number;
 }
+
+
+export type CctvReviewStatus = "CONFIRMED_SELF" | "REJECTED_SELF";
+
+export interface CctvMatchedLostItem {
+    lost_item_id: number;
+    title: string;
+    category: string;
+    match_count: number;
+    reported_at: string;
+    image_url: string | null;
+}
+
+export interface CctvMyItemsResponse {
+    matched_lost_items: CctvMatchedLostItem[];
+}
+
+export interface CctvDetection {
+    detection_id: number;
+    score: number;
+    detected_at: string;
+    building_name: string;
+    room_name: string;
+    item_snapshot_url: string | null;
+    moment_snapshot_url: string | null;
+}
+
+export interface CctvItemDetectionsResponse {
+    detections: CctvDetection[];
+}
+
+export interface CctvReviewRequest {
+    review_status: CctvReviewStatus;
+}

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -194,10 +194,9 @@ export default function MyPageScreen() {
           </TouchableOpacity>
 
           {/* CCTV 분석 카드 */}
-          {/* TODO: PM 작업 예정 - router.push(ROUTES.CCTV_RESULT) 로 변경 */}
           <TouchableOpacity
             className="flex-1 bg-white rounded-3xl p-4 border border-gray-100 shadow-sm overflow-hidden"
-            onPress={() => router.push(ROUTES.CCTV_RESULT)}
+            onPress={() => router.push(ROUTES.CCTV_ITEMS)}
             activeOpacity={0.85}
           >
             <View className="w-11 h-11 rounded-2xl bg-red-400 items-center justify-center mb-3">

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -142,6 +142,7 @@ function RootLayoutNav() {
         <Stack.Screen name="notifications" options={{ headerShown: false }} />
         <Stack.Screen name="matches" options={{ headerShown: false }} />
         <Stack.Screen name="my-qr" options={{ headerShown: false }} />
+        <Stack.Screen name="cctv-items" options={{ headerShown: false }} />
         <Stack.Screen name="cctv-result" options={{ headerShown: false }} />
       </Stack>
       <GlobalLoading />

--- a/app/cctv-items.tsx
+++ b/app/cctv-items.tsx
@@ -1,0 +1,143 @@
+import { BASE_URL, ROUTES } from "@/constants/url";
+import { useCctvQueries } from "@/hooks/queries/useCctvQueries";
+import { fonts } from "@/constants/typography";
+import { useRouter } from "expo-router";
+import { Camera, ChevronLeft, ChevronRight, Package } from "lucide-react-native";
+import {
+    ActivityIndicator,
+    FlatList,
+    Image,
+    RefreshControl,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useState } from "react";
+
+export default function CctvItemsScreen() {
+    const router = useRouter();
+    const insets = useSafeAreaInsets();
+    const [isRefreshing, setIsRefreshing] = useState(false);
+
+    const { data, isLoading, refetch } = useCctvQueries.useMyItems();
+    const items = data?.data?.data?.matched_lost_items ?? [];
+
+    const onRefresh = async () => {
+        setIsRefreshing(true);
+        await refetch();
+        setIsRefreshing(false);
+    };
+
+    if (isLoading) {
+        return (
+            <View style={[styles.container, { alignItems: "center", justifyContent: "center" }]}>
+                <ActivityIndicator color="#ef4444" size="large" />
+            </View>
+        );
+    }
+
+    return (
+        <View style={[styles.container, { paddingTop: insets.top }]}>
+            <View style={styles.header}>
+                <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
+                    <ChevronLeft size={22} color="#333" />
+                </TouchableOpacity>
+                <Text style={styles.headerTitle}>CCTV 탐지 내역</Text>
+                <View style={{ width: 36 }} />
+            </View>
+
+            <FlatList
+                data={items}
+                keyExtractor={(item) => String(item.lost_item_id)}
+                contentContainerStyle={styles.listContent}
+                showsVerticalScrollIndicator={false}
+                refreshControl={
+                    <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} colors={["#ef4444"]} tintColor="#ef4444" />
+                }
+                ListEmptyComponent={
+                    <View style={styles.emptyBox}>
+                        <View style={styles.emptyIconWrap}>
+                            <Camera size={36} color="#ef4444" />
+                        </View>
+                        <Text style={styles.emptyTitle}>탐지된 물건이 없어요</Text>
+                        <Text style={styles.emptyDesc}>CCTV에서 분실물이 탐지되면 여기에 표시돼요</Text>
+                    </View>
+                }
+                renderItem={({ item }) => {
+                    const imageUrl = item.image_url
+                        ? item.image_url.startsWith("http") ? item.image_url : `${BASE_URL}${item.image_url}`
+                        : null;
+
+                    return (
+                        <TouchableOpacity
+                            style={styles.card}
+                            activeOpacity={0.85}
+                            onPress={() =>
+                                router.push({ pathname: ROUTES.CCTV_RESULT, params: { itemId: String(item.lost_item_id) } })
+                            }
+                        >
+                            <View style={styles.thumbnail}>
+                                {imageUrl ? (
+                                    <Image source={{ uri: imageUrl }} style={styles.thumbnailImage} resizeMode="cover" />
+                                ) : (
+                                    <Package size={28} color="#ef4444" />
+                                )}
+                            </View>
+
+                            <View style={styles.info}>
+                                <Text style={styles.title} numberOfLines={1}>{item.title}</Text>
+                                <View style={styles.categoryBadge}>
+                                    <Text style={styles.categoryText}>{item.category}</Text>
+                                </View>
+                                <Text style={styles.reportedAt}>{item.reported_at}</Text>
+                            </View>
+
+                            <View style={styles.right}>
+                                <View style={styles.countBadge}>
+                                    <Text style={styles.countText}>{item.match_count}건 탐지</Text>
+                                </View>
+                                <ChevronRight size={16} color="#ccc" style={{ marginTop: 8 }} />
+                            </View>
+                        </TouchableOpacity>
+                    );
+                }}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: { flex: 1, backgroundColor: "#fff" },
+    header: {
+        flexDirection: "row", alignItems: "center", justifyContent: "space-between",
+        paddingHorizontal: 16, paddingVertical: 12,
+        borderBottomWidth: 0.5, borderBottomColor: "#f0f0f0",
+    },
+    backBtn: { width: 36, height: 36, borderRadius: 18, alignItems: "center", justifyContent: "center" },
+    headerTitle: { fontSize: 16, fontFamily: fonts.bold, color: "#111" },
+    listContent: { padding: 16, paddingBottom: 40, gap: 12 },
+    card: {
+        flexDirection: "row", alignItems: "center", backgroundColor: "#fff",
+        borderRadius: 14, borderWidth: 1, borderColor: "#f0f0f0",
+        padding: 14, gap: 12, shadowColor: "#000", shadowOpacity: 0.04, shadowRadius: 6, elevation: 2,
+    },
+    thumbnail: {
+        width: 60, height: 60, borderRadius: 12, backgroundColor: "#fef2f2",
+        alignItems: "center", justifyContent: "center", overflow: "hidden",
+    },
+    thumbnailImage: { width: 60, height: 60 },
+    info: { flex: 1, gap: 4 },
+    title: { fontSize: 14, fontFamily: fonts.bold, color: "#111" },
+    categoryBadge: { alignSelf: "flex-start", backgroundColor: "#eef2ff", borderRadius: 8, paddingHorizontal: 8, paddingVertical: 2 },
+    categoryText: { fontSize: 10, fontFamily: fonts.bold, color: "#6366f1" },
+    reportedAt: { fontSize: 11, fontFamily: fonts.regular, color: "#aaa" },
+    right: { alignItems: "center" },
+    countBadge: { backgroundColor: "#fef2f2", borderRadius: 10, paddingHorizontal: 8, paddingVertical: 4 },
+    countText: { fontSize: 11, fontFamily: fonts.bold, color: "#ef4444" },
+    emptyBox: { alignItems: "center", paddingVertical: 80, gap: 12 },
+    emptyIconWrap: { width: 72, height: 72, borderRadius: 36, backgroundColor: "#fef2f2", alignItems: "center", justifyContent: "center", marginBottom: 4 },
+    emptyTitle: { fontSize: 16, fontFamily: fonts.bold, color: "#333" },
+    emptyDesc: { fontSize: 13, fontFamily: fonts.regular, color: "#aaa", textAlign: "center" },
+});

--- a/app/cctv-items.tsx
+++ b/app/cctv-items.tsx
@@ -1,7 +1,7 @@
 import { BASE_URL, ROUTES } from "@/constants/url";
 import { useCctvQueries } from "@/hooks/queries/useCctvQueries";
 import { fonts } from "@/constants/typography";
-import { useRouter } from "expo-router";
+import { mockCctvItems } from "@/mocks/cctv"; // TODO(mock): 실서버 연동 시 이 줄 삭제
 import { Camera, ChevronLeft, ChevronRight, Package } from "lucide-react-native";
 import {
     ActivityIndicator,
@@ -15,6 +15,10 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useState } from "react";
+import { useRouter } from "expo-router";
+
+// TODO(mock): 실서버 연동 시 아래 한 줄 삭제
+const USE_MOCK = true;
 
 export default function CctvItemsScreen() {
     const router = useRouter();
@@ -22,7 +26,8 @@ export default function CctvItemsScreen() {
     const [isRefreshing, setIsRefreshing] = useState(false);
 
     const { data, isLoading, refetch } = useCctvQueries.useMyItems();
-    const items = data?.data?.data?.matched_lost_items ?? [];
+    // TODO(mock): 실서버 연동 시 → data?.data?.data?.matched_lost_items ?? []
+    const items = USE_MOCK ? mockCctvItems : (data?.data?.data?.matched_lost_items ?? []);
 
     const onRefresh = async () => {
         setIsRefreshing(true);
@@ -30,7 +35,8 @@ export default function CctvItemsScreen() {
         setIsRefreshing(false);
     };
 
-    if (isLoading) {
+    // TODO(mock): 실서버 연동 시 → if (isLoading) {
+    if (!USE_MOCK && isLoading) {
         return (
             <View style={[styles.container, { alignItems: "center", justifyContent: "center" }]}>
                 <ActivityIndicator color="#ef4444" size="large" />
@@ -124,10 +130,10 @@ const styles = StyleSheet.create({
         padding: 14, gap: 12, shadowColor: "#000", shadowOpacity: 0.04, shadowRadius: 6, elevation: 2,
     },
     thumbnail: {
-        width: 60, height: 60, borderRadius: 12, backgroundColor: "#fef2f2",
+        width: 90, height: 90, borderRadius: 14, backgroundColor: "#fef2f2",
         alignItems: "center", justifyContent: "center", overflow: "hidden",
     },
-    thumbnailImage: { width: 60, height: 60 },
+    thumbnailImage: { width: 90, height: 90 },
     info: { flex: 1, gap: 4 },
     title: { fontSize: 14, fontFamily: fonts.bold, color: "#111" },
     categoryBadge: { alignSelf: "flex-start", backgroundColor: "#eef2ff", borderRadius: 8, paddingHorizontal: 8, paddingVertical: 2 },

--- a/app/cctv-result.tsx
+++ b/app/cctv-result.tsx
@@ -1,660 +1,263 @@
+import { BASE_URL, ROUTES } from "@/constants/url";
+import { useCctvMutations } from "@/hooks/mutations/useCctvMutations";
+import { useCctvQueries } from "@/hooks/queries/useCctvQueries";
 import { fonts } from "@/constants/typography";
-import { BASE_URL } from "@/constants/url";
-import { useRouter } from "expo-router";
-import {
-  Camera,
-  CheckCircle2,
-  ChevronLeft,
-  Clock,
-  MapPin,
-  Sparkles,
-  Video,
-  XCircle,
-} from "lucide-react-native";
+import { CctvDetection, CctvReviewStatus } from "@/api/types";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Camera, CheckCircle2, ChevronLeft, Clock, HelpCircle, MapPin, Video, XCircle } from "lucide-react-native";
 import { useEffect, useState } from "react";
 import {
-  ActivityIndicator,
-  Image,
-  Modal,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
+    ActivityIndicator, Dimensions, Image, Modal, Pressable,
+    ScrollView, StyleSheet, Text, TouchableOpacity, View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 
-type DetectionStatus = "CONFIRMED_SELF" | "REJECTED_SELF" | null;
-
-type Detection = {
-  detection_id: string;
-  snapshot_url: string | null;
-  detected_at: string;
-  location: string;
-  score: number;
-  review_status: DetectionStatus;
-};
-
-type CctvResultState =
-  | {
-      ready: false;
-      totalVideos: number;
-      resolvedVideos: number;
-      estimatedRemainingSeconds: number;
-    }
-  | { ready: true; matches: Detection[] };
-
-// 더미 데이터 (백엔드 API 추가 시 교체)
-const MOCK_PROGRESS: CctvResultState = {
-  ready: false,
-  totalVideos: 5,
-  resolvedVideos: 2,
-  estimatedRemainingSeconds: 180,
-};
-
-const MOCK_COMPLETE: CctvResultState = {
-  ready: true,
-  matches: [
-    {
-      detection_id: "det-1",
-      snapshot_url: null,
-      detected_at: "2026-05-11T14:30:00",
-      location: "제1공학관 3층 복도",
-      score: 0.87,
-      review_status: null,
-    },
-    {
-      detection_id: "det-2",
-      snapshot_url: null,
-      detected_at: "2026-05-11T15:12:00",
-      location: "학생회관 1층 카페",
-      score: 0.81,
-      review_status: null,
-    },
-  ],
-};
+const { width: screenWidth } = Dimensions.get("window");
+const SNAPSHOT_WIDTH = (screenWidth - 32) / 2;
 
 function formatDateTime(dateStr: string) {
-  const d = new Date(dateStr);
-  const h = d.getHours();
-  const ampm = h < 12 ? "오전" : "오후";
-  const hh = h % 12 === 0 ? 12 : h % 12;
-  return `${d.getMonth() + 1}월 ${d.getDate()}일 ${ampm} ${String(hh).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
-}
-
-function formatRemaining(seconds: number) {
-  const min = Math.floor(seconds / 60);
-  if (min < 1) return "1분 이내";
-  return `약 ${min}분`;
+    const d = new Date(dateStr);
+    const h = d.getHours();
+    const ampm = h < 12 ? "오전" : "오후";
+    const hh = h % 12 === 0 ? 12 : h % 12;
+    return `${d.getMonth() + 1}월 ${d.getDate()}일 ${ampm} ${String(hh).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
 export default function CctvResultScreen() {
-  const router = useRouter();
-  const insets = useSafeAreaInsets();
-  const [data, setData] = useState<CctvResultState>(MOCK_PROGRESS);
-  const [isLoading, setIsLoading] = useState(true);
-  const [selectedDetection, setSelectedDetection] = useState<Detection | null>(
-    null,
-  );
-  const [modalType, setModalType] = useState<"confirm" | "reject" | null>(null);
+    const router = useRouter();
+    const insets = useSafeAreaInsets();
+    const { itemId } = useLocalSearchParams<{ itemId: string }>();
+    const parsedItemId = Number(itemId);
 
-  // TODO: 백엔드 API 추가 후 실제 호출로 교체
-  // GET /api/cctv/analyze?itemId={id}
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-      // 더미: 5초 후 완료 상태로 전환 (테스트용)
-      setTimeout(() => setData(MOCK_COMPLETE), 5000);
-    }, 800);
-    return () => clearTimeout(timer);
-  }, []);
+    const [selectedDetection, setSelectedDetection] = useState<CctvDetection | null>(null);
+    const [modalType, setModalType] = useState<"confirm" | "reject" | null>(null);
+    const [localReviewed, setLocalReviewed] = useState<Record<number, CctvReviewStatus>>({});
 
-  const openModal = (detection: Detection, type: "confirm" | "reject") => {
-    setSelectedDetection(detection);
-    setModalType(type);
-  };
+    const { data, isLoading, refetch } = useCctvQueries.useItemDetections(parsedItemId);
+    const reviewMutation = useCctvMutations.useReviewDetection(parsedItemId);
+    const responseData = data?.data?.data;
 
-  const closeModal = () => {
-    setSelectedDetection(null);
-    setModalType(null);
-  };
+    const openModal = (detection: CctvDetection, type: "confirm" | "reject") => {
+        setSelectedDetection(detection);
+        setModalType(type);
+    };
+    const closeModal = () => { setSelectedDetection(null); setModalType(null); };
 
-  // TODO: PUT /api/cctv/detections/{id}/review API 연결
-  const handleReview = (status: "CONFIRMED_SELF" | "REJECTED_SELF") => {
-    if (!selectedDetection) return;
-    const updated = { ...selectedDetection, review_status: status };
-    closeModal();
+    const handleReview = (status: CctvReviewStatus) => {
+        if (!selectedDetection) return;
+        closeModal();
+        reviewMutation.mutate(
+            { detectionId: selectedDetection.detection_id, body: { review_status: status } },
+            {
+                onSuccess: () => {
+                    setLocalReviewed((prev) => ({ ...prev, [selectedDetection.detection_id]: status }));
+                    if (status === "CONFIRMED_SELF") {
+                        Toast.show({ type: "success", text1: "내 물건으로 확인했어요", position: "bottom", visibilityTime: 2000 });
+                        router.push(ROUTES.MATCHES);
+                    } else if (status === "REJECTED_SELF") {
+                        Toast.show({ type: "success", text1: "도난 의심 신고가 접수됐어요", position: "bottom", visibilityTime: 2500 });
+                    } else {
+                        Toast.show({ type: "info", text1: "나중에 다시 확인할게요", position: "bottom", visibilityTime: 2000 });
+                    }
+                },
+                onError: () => {
+                    Toast.show({ type: "error", text1: "처리 실패", text2: "다시 시도해주세요.", position: "bottom", visibilityTime: 2500 });
+                },
+            }
+        );
+    };
 
-    // 임시 로컬 상태 업데이트
-    if (data.ready) {
-      setData({
-        ...data,
-        matches: data.matches.map((m) =>
-          m.detection_id === updated.detection_id ? updated : m,
-        ),
-      });
+    if (isLoading) {
+        return (
+            <View style={[styles.container, { alignItems: "center", justifyContent: "center" }]}>
+                <ActivityIndicator color="#ef4444" size="large" />
+            </View>
+        );
     }
 
-    Toast.show({
-      type: "success",
-      text1:
-        status === "CONFIRMED_SELF"
-          ? "내 물건으로 확정했어요"
-          : "내 물건이 아닌 것으로 표시했어요",
-      position: "bottom",
-      visibilityTime: 2000,
-    });
-  };
+    const detections = responseData?.detections ?? [];
 
-  if (isLoading) {
     return (
-      <View
-        style={[
-          styles.container,
-          { alignItems: "center", justifyContent: "center" },
-        ]}
-      >
-        <ActivityIndicator color="#6366f1" size="large" />
-      </View>
-    );
-  }
-
-  return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
-      {/* 헤더 */}
-      <View style={styles.header}>
-        <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
-          <ChevronLeft size={22} color="#333" />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>CCTV 분석 결과</Text>
-        <View style={{ width: 36 }} />
-      </View>
-
-      <ScrollView
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingBottom: 40 }}
-      >
-        {/* 진행 중 상태 */}
-        {!data.ready ? (
-          <View style={styles.progressBox}>
-            <View style={styles.progressIconWrap}>
-              <Video size={36} color="#6366f1" />
-            </View>
-            <Text style={styles.progressTitle}>분석 진행 중이에요</Text>
-            <Text style={styles.progressDesc}>
-              CCTV 영상을 분석해서 분실물을{"\n"}찾고 있어요. 잠시만
-              기다려주세요!
-            </Text>
-
-            {/* 진행률 바 */}
-            <View style={styles.progressBarWrap}>
-              <View style={styles.progressBarBg}>
-                <View
-                  style={[
-                    styles.progressBarFill,
-                    {
-                      width: `${(data.resolvedVideos / data.totalVideos) * 100}%`,
-                    },
-                  ]}
-                />
-              </View>
-              <View style={styles.progressInfo}>
-                <Text style={styles.progressInfoText}>
-                  {data.resolvedVideos} / {data.totalVideos} 영상 분석 완료
-                </Text>
-                <Text style={styles.progressInfoText}>
-                  {formatRemaining(data.estimatedRemainingSeconds)}
-                </Text>
-              </View>
+        <View style={[styles.container, { paddingTop: insets.top }]}>
+            <View style={styles.header}>
+                <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
+                    <ChevronLeft size={22} color="#333" />
+                </TouchableOpacity>
+                <Text style={styles.headerTitle}>CCTV 분석 결과</Text>
+                <View style={{ width: 36 }} />
             </View>
 
-            <View style={styles.progressTip}>
-              <Clock size={14} color="#888" />
-              <Text style={styles.progressTipText}>
-                분석이 완료되면 푸시 알림으로 알려드릴게요
-              </Text>
-            </View>
-          </View>
-        ) : (
-          // 완료 상태
-          <>
-            <View style={styles.intro}>
-              <View style={styles.introIcon}>
-                <Sparkles size={20} color="#6366f1" />
-              </View>
-              <View style={{ flex: 1 }}>
-                <Text style={styles.introTitle}>
-                  CCTV에서 {data.matches.length}개 검출됐어요
-                </Text>
-                <Text style={styles.introDesc}>
-                  스냅샷을 확인하고 내 물건이 맞는지 알려주세요
-                </Text>
-              </View>
-            </View>
-
-            {data.matches.length === 0 ? (
-              <View style={styles.emptyBox}>
-                <View style={styles.emptyIconWrap}>
-                  <Camera size={36} color="#6366f1" />
-                </View>
-                <Text style={styles.emptyTitle}>검출된 결과가 없어요</Text>
-                <Text style={styles.emptyDesc}>
-                  분석한 영상에서 분실물과{"\n"}유사한 장면을 찾지 못했어요
-                </Text>
-              </View>
-            ) : (
-              data.matches.map((det) => {
-                const scorePercent = Math.round(det.score * 100);
-                const isReviewed = det.review_status !== null;
-                const isConfirmed = det.review_status === "CONFIRMED_SELF";
-                const isRejected = det.review_status === "REJECTED_SELF";
-
-                return (
-                  <View key={det.detection_id} style={styles.card}>
-                    {/* 점수 배지 + 상태 */}
-                    <View style={styles.cardTopRow}>
-                      <View style={styles.scoreBadge}>
-                        <Sparkles size={12} color="#6366f1" />
-                        <Text style={styles.scoreText}>
-                          유사도 {scorePercent}%
-                        </Text>
-                      </View>
-                      {isReviewed && (
-                        <View
-                          style={[
-                            styles.statusBadge,
-                            isConfirmed
-                              ? styles.statusBadgeConfirmed
-                              : styles.statusBadgeRejected,
-                          ]}
-                        >
-                          <Text
-                            style={[
-                              styles.statusBadgeText,
-                              isConfirmed
-                                ? styles.statusBadgeTextConfirmed
-                                : styles.statusBadgeTextRejected,
-                            ]}
-                          >
-                            {isConfirmed ? "내 물건 확정" : "내 거 아님"}
-                          </Text>
+            <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ paddingBottom: 40 }}>
+                {detections.length === 0 ? (
+                    <View style={styles.emptyBox}>
+                        <View style={styles.emptyIconWrap}><Camera size={36} color="#ef4444" /></View>
+                        <Text style={styles.emptyTitle}>검출된 결과가 없어요</Text>
+                        <Text style={styles.emptyDesc}>분석한 영상에서 분실물과{"\n"}유사한 장면을 찾지 못했어요</Text>
+                    </View>
+                ) : (
+                    <>
+                        <View style={styles.intro}>
+                            <Text style={styles.introTitle}>CCTV에서 {detections.length}개 검출됐어요</Text>
+                            <Text style={styles.introDesc}>스냅샷을 확인하고 내 물건이 맞는지 알려주세요</Text>
                         </View>
-                      )}
-                    </View>
 
-                    {/* 스냅샷 */}
-                    {det.snapshot_url ? (
-                      <Image
-                        source={{
-                          uri: det.snapshot_url.startsWith("http")
-                            ? det.snapshot_url
-                            : `${BASE_URL}${det.snapshot_url}`,
-                        }}
-                        style={styles.snapshot}
-                        resizeMode="cover"
-                      />
-                    ) : (
-                      <View style={styles.snapshotPlaceholder}>
-                        <Video size={36} color="#6366f1" />
-                        <Text style={styles.snapshotPlaceholderText}>
-                          스냅샷 미리보기
+                        {detections.map((det) => {
+                            const reviewed = localReviewed[det.detection_id];
+                            const isReviewed = reviewed !== undefined;
+                            const scorePercent = Math.round(det.score * 100);
+                            const itemSnapshotUri = det.item_snapshot_url
+                                ? det.item_snapshot_url.startsWith("http") ? det.item_snapshot_url : `${BASE_URL}${det.item_snapshot_url}`
+                                : null;
+                            const momentSnapshotUri = det.moment_snapshot_url
+                                ? det.moment_snapshot_url.startsWith("http") ? det.moment_snapshot_url : `${BASE_URL}${det.moment_snapshot_url}`
+                                : null;
+
+                            return (
+                                <View key={det.detection_id} style={styles.card}>
+                                    <View style={styles.cardTopRow}>
+                                        <View style={styles.scoreBadge}>
+                                            <Text style={styles.scoreText}>유사도 {scorePercent}%</Text>
+                                        </View>
+                                        {isReviewed && (
+                                            <View style={[styles.statusBadge,
+                                                reviewed === "CONFIRMED_SELF" ? styles.statusConfirmed
+                                                    : reviewed === "REJECTED_SELF" ? styles.statusRejected
+                                                        : styles.statusUncertain]}>
+                                                <Text style={styles.statusBadgeText}>
+                                                    {reviewed === "CONFIRMED_SELF" ? "내 물건 확정" : reviewed === "REJECTED_SELF" ? "내 거 아님" : "미확인"}
+                                                </Text>
+                                            </View>
+                                        )}
+                                    </View>
+
+                                    {/* 듀얼 스냅샷 */}
+                                    <View style={styles.snapshotRow}>
+                                        <View style={[styles.snapshotWrap, { width: SNAPSHOT_WIDTH }]}>
+                                            <Text style={styles.snapshotLabel}>내 물건</Text>
+                                            {itemSnapshotUri ? (
+                                                <Image source={{ uri: itemSnapshotUri }} style={[styles.snapshot, { width: SNAPSHOT_WIDTH }]} resizeMode="cover" />
+                                            ) : (
+                                                <View style={[styles.snapshotPlaceholder, { width: SNAPSHOT_WIDTH }]}><Video size={24} color="#ef4444" /></View>
+                                            )}
+                                        </View>
+                                        <View style={[styles.snapshotWrap, { width: SNAPSHOT_WIDTH }]}>
+                                            <Text style={styles.snapshotLabel}>발견 순간</Text>
+                                            {momentSnapshotUri ? (
+                                                <Image source={{ uri: momentSnapshotUri }} style={[styles.snapshot, { width: SNAPSHOT_WIDTH }]} resizeMode="cover" />
+                                            ) : (
+                                                <View style={[styles.snapshotPlaceholder, { width: SNAPSHOT_WIDTH }]}><Camera size={24} color="#ef4444" /></View>
+                                            )}
+                                        </View>
+                                    </View>
+
+                                    <View style={styles.info}>
+                                        <View style={styles.infoRow}><MapPin size={14} color="#888" /><Text style={styles.infoText}>{det.building_name} {det.room_name}</Text></View>
+                                        <View style={styles.infoRow}><Clock size={14} color="#888" /><Text style={styles.infoText}>{formatDateTime(det.detected_at)}</Text></View>
+                                    </View>
+
+                                    {!isReviewed && (
+                                        <View style={styles.btnRow}>
+                                            <TouchableOpacity style={styles.rejectBtn} onPress={() => openModal(det, "reject")} activeOpacity={0.85}>
+                                                <XCircle size={14} color="#888" />
+                                                <Text style={styles.rejectBtnText}>아니에요</Text>
+                                            </TouchableOpacity>
+                                            <TouchableOpacity style={styles.confirmBtn} onPress={() => openModal(det, "confirm")} activeOpacity={0.85}>
+                                                <CheckCircle2 size={14} color="#fff" />
+                                                <Text style={styles.confirmBtnText}>맞아요</Text>
+                                            </TouchableOpacity>
+                                        </View>
+                                    )}
+                                </View>
+                            );
+                        })}
+                    </>
+                )}
+            </ScrollView>
+
+            <Modal visible={modalType !== null} transparent animationType="fade">
+                <Pressable style={styles.modalOverlay} onPress={closeModal} />
+                <View style={styles.modalWrap}>
+                    <View style={styles.modalCard}>
+                        <Text style={styles.modalTitle}>
+                            {modalType === "confirm" ? "내 물건이 맞나요?" : "내 물건이 아닌가요?"}
                         </Text>
-                      </View>
-                    )}
-
-                    {/* 정보 */}
-                    <View style={styles.info}>
-                      <View style={styles.infoRow}>
-                        <MapPin size={14} color="#888" />
-                        <Text style={styles.infoText}>{det.location}</Text>
-                      </View>
-                      <View style={styles.infoRow}>
-                        <Clock size={14} color="#888" />
-                        <Text style={styles.infoText}>
-                          {formatDateTime(det.detected_at)}
+                        <Text style={styles.modalDesc}>
+                            {modalType === "confirm" ? "확정하면 매칭 절차가 진행되며,\n취소할 수 없어요."
+                                : "아닌 것으로 표시하면 도난 의심 신고가\n자동 접수돼요."}
                         </Text>
-                      </View>
+                        <TouchableOpacity
+                            style={[styles.modalBtn, modalType === "confirm" ? styles.modalBtnPrimary : styles.modalBtnDanger]}
+                            onPress={() => handleReview(modalType === "confirm" ? "CONFIRMED_SELF" : "REJECTED_SELF")}
+                        >
+                            <Text style={styles.modalBtnText}>
+                                {modalType === "confirm" ? "확정하기" : "신고하기"}
+                            </Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity style={styles.cancelBtn} onPress={closeModal}>
+                            <Text style={styles.cancelBtnText}>취소</Text>
+                        </TouchableOpacity>
                     </View>
-
-                    {/* 3택 버튼 (미리뷰일 때만) */}
-                    {!isReviewed && (
-                      <View style={styles.btnRow}>
-                        <TouchableOpacity
-                          style={styles.rejectBtn}
-                          onPress={() => openModal(det, "reject")}
-                          activeOpacity={0.85}
-                        >
-                          <XCircle size={14} color="#888" />
-                          <Text style={styles.rejectBtnText}>아니에요</Text>
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                          style={styles.confirmBtn}
-                          onPress={() => openModal(det, "confirm")}
-                          activeOpacity={0.85}
-                        >
-                          <CheckCircle2 size={14} color="#fff" />
-                          <Text style={styles.confirmBtnText}>맞아요</Text>
-                        </TouchableOpacity>
-                      </View>
-                    )}
-                  </View>
-                );
-              })
-            )}
-          </>
-        )}
-      </ScrollView>
-
-      {/* 확인 모달 */}
-      <Modal visible={modalType !== null} transparent animationType="fade">
-        <Pressable style={styles.modalOverlay} onPress={closeModal} />
-        <View style={styles.modalWrap}>
-          <View style={styles.modalCard}>
-            <Text style={styles.modalTitle}>
-              {modalType === "confirm"
-                ? "내 물건이 맞나요?"
-                : "내 물건이 아닌가요?"}
-            </Text>
-            <Text style={styles.modalDesc}>
-              {modalType === "confirm"
-                ? "확정하면 회수 절차가 진행되며,\n취소할 수 없어요."
-                : "거절한 검출은 다시 받을 수 없어요."}
-            </Text>
-            <TouchableOpacity
-              style={[
-                styles.modalBtn,
-                modalType === "confirm"
-                  ? styles.modalBtnPrimary
-                  : styles.modalBtnDanger,
-              ]}
-              onPress={() =>
-                handleReview(
-                  modalType === "confirm" ? "CONFIRMED_SELF" : "REJECTED_SELF",
-                )
-              }
-            >
-              <Text style={styles.modalBtnText}>
-                {modalType === "confirm" ? "확정하기" : "거절하기"}
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.cancelBtn} onPress={closeModal}>
-              <Text style={styles.cancelBtnText}>취소</Text>
-            </TouchableOpacity>
-          </View>
+                </View>
+            </Modal>
         </View>
-      </Modal>
-    </View>
-  );
+    );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#fff" },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderBottomWidth: 0.5,
-    borderBottomColor: "#f0f0f0",
-  },
-  backBtn: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  headerTitle: { fontSize: 16, fontFamily: fonts.bold, color: "#111" },
-
-  // 진행 중
-  progressBox: {
-    alignItems: "center",
-    paddingTop: 60,
-    paddingHorizontal: 32,
-    gap: 12,
-  },
-  progressIconWrap: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: "#eef2ff",
-    alignItems: "center",
-    justifyContent: "center",
-    marginBottom: 8,
-  },
-  progressTitle: { fontSize: 18, fontFamily: fonts.bold, color: "#111" },
-  progressDesc: {
-    fontSize: 13,
-    fontFamily: fonts.regular,
-    color: "#888",
-    textAlign: "center",
-    lineHeight: 20,
-    marginBottom: 20,
-  },
-  progressBarWrap: { width: "100%", gap: 8 },
-  progressBarBg: {
-    width: "100%",
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: "#eef2ff",
-    overflow: "hidden",
-  },
-  progressBarFill: {
-    height: "100%",
-    backgroundColor: "#6366f1",
-    borderRadius: 4,
-  },
-  progressInfo: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-  },
-  progressInfoText: { fontSize: 12, fontFamily: fonts.regular, color: "#888" },
-  progressTip: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    marginTop: 12,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    backgroundColor: "#fafbff",
-    borderRadius: 10,
-  },
-  progressTipText: { fontSize: 11, fontFamily: fonts.regular, color: "#888" },
-
-  // 완료
-  intro: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: "#eef2ff",
-    marginHorizontal: 16,
-    marginTop: 16,
-    marginBottom: 12,
-    borderRadius: 14,
-    padding: 14,
-    gap: 12,
-  },
-  introIcon: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  introTitle: {
-    fontSize: 13,
-    fontFamily: fonts.bold,
-    color: "#6366f1",
-    marginBottom: 2,
-  },
-  introDesc: {
-    fontSize: 11,
-    fontFamily: fonts.regular,
-    color: "#6366f1",
-    opacity: 0.8,
-  },
-
-  // 카드
-  card: {
-    backgroundColor: "#fff",
-    marginHorizontal: 16,
-    marginBottom: 12,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: "#f0f0f0",
-    overflow: "hidden",
-    shadowColor: "#000",
-    shadowOpacity: 0.04,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  cardTopRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingHorizontal: 14,
-    paddingTop: 14,
-    paddingBottom: 10,
-  },
-  scoreBadge: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-    backgroundColor: "#eef2ff",
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 12,
-  },
-  scoreText: { fontSize: 11, fontFamily: fonts.bold, color: "#6366f1" },
-  statusBadge: {
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 12,
-  },
-  statusBadgeConfirmed: { backgroundColor: "#dcfce7" },
-  statusBadgeRejected: { backgroundColor: "#f5f6f8" },
-  statusBadgeText: { fontSize: 11, fontFamily: fonts.bold },
-  statusBadgeTextConfirmed: { color: "#16a34a" },
-  statusBadgeTextRejected: { color: "#888" },
-
-  snapshot: { width: "100%", height: 200, backgroundColor: "#f5f6f8" },
-  snapshotPlaceholder: {
-    width: "100%",
-    height: 200,
-    backgroundColor: "#eef2ff",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 8,
-  },
-  snapshotPlaceholderText: {
-    fontSize: 11,
-    fontFamily: fonts.regular,
-    color: "#6366f1",
-  },
-
-  info: { paddingHorizontal: 14, paddingTop: 12, paddingBottom: 14, gap: 6 },
-  infoRow: { flexDirection: "row", alignItems: "center", gap: 6 },
-  infoText: { fontSize: 12, fontFamily: fonts.regular, color: "#555" },
-
-  // 3택 버튼
-  btnRow: {
-    flexDirection: "row",
-    gap: 6,
-    paddingHorizontal: 14,
-    paddingBottom: 14,
-  },
-  rejectBtn: {
-    flex: 1,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 4,
-    paddingVertical: 12,
-    borderRadius: 12,
-    backgroundColor: "#f5f6f8",
-  },
-  rejectBtnText: { fontSize: 12, fontFamily: fonts.bold, color: "#888" },
-  confirmBtn: {
-    flex: 1.2,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 4,
-    paddingVertical: 12,
-    borderRadius: 12,
-    backgroundColor: "#6366f1",
-    shadowColor: "#6366f1",
-    shadowOpacity: 0.3,
-    shadowRadius: 6,
-    elevation: 3,
-  },
-  confirmBtnText: { fontSize: 12, fontFamily: fonts.bold, color: "#fff" },
-
-  // 빈 상태
-  emptyBox: { alignItems: "center", paddingVertical: 80, gap: 12 },
-  emptyIconWrap: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: "#eef2ff",
-    alignItems: "center",
-    justifyContent: "center",
-    marginBottom: 4,
-  },
-  emptyTitle: { fontSize: 16, fontFamily: fonts.bold, color: "#333" },
-  emptyDesc: {
-    fontSize: 13,
-    fontFamily: fonts.regular,
-    color: "#aaa",
-    textAlign: "center",
-    lineHeight: 19,
-  },
-
-  // 모달
-  modalOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.4)",
-  },
-  modalWrap: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 32,
-  },
-  modalCard: {
-    width: "100%",
-    backgroundColor: "#fff",
-    borderRadius: 20,
-    padding: 24,
-    gap: 12,
-    shadowColor: "#000",
-    shadowOpacity: 0.1,
-    shadowRadius: 16,
-    elevation: 8,
-  },
-  modalTitle: { fontSize: 17, fontFamily: fonts.bold, color: "#111" },
-  modalDesc: {
-    fontSize: 13,
-    fontFamily: fonts.regular,
-    color: "#666",
-    lineHeight: 19,
-  },
-  modalBtn: {
-    borderRadius: 12,
-    paddingVertical: 14,
-    alignItems: "center",
-    marginTop: 4,
-  },
-  modalBtnPrimary: { backgroundColor: "#6366f1" },
-  modalBtnDanger: { backgroundColor: "#f87171" },
-  modalBtnText: { fontSize: 15, fontFamily: fonts.bold, color: "#fff" },
-  cancelBtn: { paddingVertical: 10, alignItems: "center" },
-  cancelBtnText: { fontSize: 14, fontFamily: fonts.regular, color: "#aaa" },
+    container: { flex: 1, backgroundColor: "#fff" },
+    header: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 0.5, borderBottomColor: "#f0f0f0" },
+    backBtn: { width: 36, height: 36, borderRadius: 18, alignItems: "center", justifyContent: "center" },
+    headerTitle: { fontSize: 16, fontFamily: fonts.bold, color: "#111" },
+    progressBox: { alignItems: "center", padding: 32, gap: 16 },
+    progressIconWrap: { width: 72, height: 72, borderRadius: 36, backgroundColor: "#fef2f2", alignItems: "center", justifyContent: "center" },
+    progressTitle: { fontSize: 18, fontFamily: fonts.bold, color: "#111" },
+    progressDesc: { fontSize: 14, fontFamily: fonts.regular, color: "#666", textAlign: "center", lineHeight: 22 },
+    progressBarWrap: { width: "100%", gap: 8 },
+    progressBarBg: { height: 8, backgroundColor: "#f5f6f8", borderRadius: 4, overflow: "hidden" },
+    progressBarFill: { height: 8, backgroundColor: "#ef4444", borderRadius: 4 },
+    progressInfoText: { fontSize: 12, fontFamily: fonts.regular, color: "#888", textAlign: "right" },
+    progressTip: { flexDirection: "row", alignItems: "center", gap: 6 },
+    progressTipText: { fontSize: 12, fontFamily: fonts.regular, color: "#888" },
+    emptyBox: { alignItems: "center", paddingVertical: 80, gap: 12 },
+    emptyIconWrap: { width: 72, height: 72, borderRadius: 36, backgroundColor: "#fef2f2", alignItems: "center", justifyContent: "center", marginBottom: 4 },
+    emptyTitle: { fontSize: 16, fontFamily: fonts.bold, color: "#333" },
+    emptyDesc: { fontSize: 13, fontFamily: fonts.regular, color: "#aaa", textAlign: "center" },
+    intro: { padding: 16, gap: 4 },
+    introTitle: { fontSize: 16, fontFamily: fonts.bold, color: "#111" },
+    introDesc: { fontSize: 13, fontFamily: fonts.regular, color: "#888" },
+    card: { marginHorizontal: 16, marginBottom: 16, backgroundColor: "#fff", borderRadius: 16, borderWidth: 1, borderColor: "#f0f0f0", overflow: "hidden", shadowColor: "#000", shadowOpacity: 0.04, shadowRadius: 8, elevation: 2 },
+    cardTopRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", padding: 14, paddingBottom: 8 },
+    scoreBadge: { backgroundColor: "#fef2f2", borderRadius: 12, paddingHorizontal: 10, paddingVertical: 5 },
+    scoreText: { fontSize: 11, fontFamily: fonts.bold, color: "#ef4444" },
+    statusBadge: { borderRadius: 12, paddingHorizontal: 10, paddingVertical: 5 },
+    statusConfirmed: { backgroundColor: "#dcfce7" },
+    statusRejected: { backgroundColor: "#fee2e2" },
+    statusUncertain: { backgroundColor: "#fef9c3" },
+    statusBadgeText: { fontSize: 11, fontFamily: fonts.bold, color: "#333" },
+    snapshotRow: { flexDirection: "row" },
+    snapshotWrap: { gap: 4, padding: 8 },
+    snapshotLabel: { fontSize: 11, fontFamily: fonts.bold, color: "#888", paddingHorizontal: 4 },
+    snapshot: { height: 140, borderRadius: 8, backgroundColor: "#f5f6f8" },
+    snapshotPlaceholder: { height: 140, borderRadius: 8, backgroundColor: "#fef2f2", alignItems: "center", justifyContent: "center" },
+    info: { paddingHorizontal: 14, paddingVertical: 10, gap: 6 },
+    infoRow: { flexDirection: "row", alignItems: "center", gap: 6 },
+    infoText: { fontSize: 13, fontFamily: fonts.regular, color: "#555" },
+    btnRow: { flexDirection: "row", gap: 6, padding: 14, paddingTop: 6 },
+    rejectBtn: { flex: 1, flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 4, paddingVertical: 10, borderRadius: 10, backgroundColor: "#f5f6f8" },
+    rejectBtnText: { fontSize: 12, fontFamily: fonts.bold, color: "#888" },
+    confirmBtn: { flex: 1, flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 4, paddingVertical: 10, borderRadius: 10, backgroundColor: "#ef4444" },
+    confirmBtnText: { fontSize: 12, fontFamily: fonts.bold, color: "#fff" },
+    modalOverlay: { ...StyleSheet.absoluteFillObject, backgroundColor: "rgba(0,0,0,0.4)" },
+    modalWrap: { position: "absolute", top: 0, left: 0, right: 0, bottom: 0, alignItems: "center", justifyContent: "center", paddingHorizontal: 32 },
+    modalCard: { width: "100%", backgroundColor: "#fff", borderRadius: 20, padding: 24, gap: 12, shadowColor: "#000", shadowOpacity: 0.1, shadowRadius: 16, elevation: 8 },
+    modalTitle: { fontSize: 17, fontFamily: fonts.bold, color: "#111" },
+    modalDesc: { fontSize: 13, fontFamily: fonts.regular, color: "#666", lineHeight: 19 },
+    modalBtn: { borderRadius: 12, paddingVertical: 14, alignItems: "center", marginTop: 4 },
+    modalBtnPrimary: { backgroundColor: "#ef4444" },
+    modalBtnDanger: { backgroundColor: "#f87171" },
+    modalBtnWarning: { backgroundColor: "#f59e0b" },
+    modalBtnText: { fontSize: 15, fontFamily: fonts.bold, color: "#fff" },
+    cancelBtn: { paddingVertical: 10, alignItems: "center" },
+    cancelBtnText: { fontSize: 14, fontFamily: fonts.regular, color: "#aaa" },
 });

--- a/app/cctv-result.tsx
+++ b/app/cctv-result.tsx
@@ -3,7 +3,7 @@ import { useCctvMutations } from "@/hooks/mutations/useCctvMutations";
 import { useCctvQueries } from "@/hooks/queries/useCctvQueries";
 import { fonts } from "@/constants/typography";
 import { CctvDetection, CctvReviewStatus } from "@/api/types";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { mockCctvDetectionsByItemId } from "@/mocks/cctv"; // TODO(mock): 실서버 연동 시 이 줄 삭제
 import { Camera, CheckCircle2, ChevronLeft, Clock, HelpCircle, MapPin, Video, XCircle } from "lucide-react-native";
 import { useEffect, useState } from "react";
 import {
@@ -12,6 +12,10 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
+import { useLocalSearchParams, useRouter } from "expo-router";
+
+// TODO(mock): 실서버 연동 시 아래 한 줄 삭제
+const USE_MOCK = true;
 
 const { width: screenWidth } = Dimensions.get("window");
 const SNAPSHOT_WIDTH = (screenWidth - 32) / 2;
@@ -34,7 +38,7 @@ export default function CctvResultScreen() {
     const [modalType, setModalType] = useState<"confirm" | "reject" | null>(null);
     const [localReviewed, setLocalReviewed] = useState<Record<number, CctvReviewStatus>>({});
 
-    const { data, isLoading, refetch } = useCctvQueries.useItemDetections(parsedItemId);
+    const { data, isLoading } = useCctvQueries.useItemDetections(parsedItemId);
     const reviewMutation = useCctvMutations.useReviewDetection(parsedItemId);
     const responseData = data?.data?.data;
 
@@ -68,7 +72,8 @@ export default function CctvResultScreen() {
         );
     };
 
-    if (isLoading) {
+    // TODO(mock): 실서버 연동 시 → if (isLoading) {
+    if (!USE_MOCK && isLoading) {
         return (
             <View style={[styles.container, { alignItems: "center", justifyContent: "center" }]}>
                 <ActivityIndicator color="#ef4444" size="large" />
@@ -76,7 +81,10 @@ export default function CctvResultScreen() {
         );
     }
 
-    const detections = responseData?.detections ?? [];
+    // TODO(mock): 실서버 연동 시 → responseData?.detections ?? []
+    const detections = USE_MOCK
+        ? (mockCctvDetectionsByItemId[parsedItemId] ?? [])
+        : (responseData?.detections ?? []);
 
     return (
         <View style={[styles.container, { paddingTop: insets.top }]}>

--- a/app/cctv-result.tsx
+++ b/app/cctv-result.tsx
@@ -1,13 +1,13 @@
-import { BASE_URL, ROUTES } from "@/constants/url";
+import { BASE_URL } from "@/constants/url";
 import { useCctvMutations } from "@/hooks/mutations/useCctvMutations";
 import { useCctvQueries } from "@/hooks/queries/useCctvQueries";
 import { fonts } from "@/constants/typography";
 import { CctvDetection, CctvReviewStatus } from "@/api/types";
 import { mockCctvDetectionsByItemId } from "@/mocks/cctv"; // TODO(mock): 실서버 연동 시 이 줄 삭제
-import { Camera, CheckCircle2, ChevronLeft, Clock, HelpCircle, MapPin, Video, XCircle } from "lucide-react-native";
-import { useEffect, useState } from "react";
+import { Camera, CheckCircle2, ChevronLeft, Clock, HelpCircle, MapPin, Phone, Video, XCircle } from "lucide-react-native";
+import { useState } from "react";
 import {
-    ActivityIndicator, Dimensions, Image, Modal, Pressable,
+    ActivityIndicator, Dimensions, Image, Linking, Modal, Pressable,
     ScrollView, StyleSheet, Text, TouchableOpacity, View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -37,6 +37,7 @@ export default function CctvResultScreen() {
     const [selectedDetection, setSelectedDetection] = useState<CctvDetection | null>(null);
     const [modalType, setModalType] = useState<"confirm" | "reject" | null>(null);
     const [localReviewed, setLocalReviewed] = useState<Record<number, CctvReviewStatus>>({});
+    const [rejectedIds, setRejectedIds] = useState<Set<number>>(new Set());
 
     const { data, isLoading } = useCctvQueries.useItemDetections(parsedItemId);
     const reviewMutation = useCctvMutations.useReviewDetection(parsedItemId);
@@ -48,6 +49,23 @@ export default function CctvResultScreen() {
     };
     const closeModal = () => { setSelectedDetection(null); setModalType(null); };
 
+    const handleConfirmAndCall = () => {
+        if (!selectedDetection) return;
+        Linking.openURL("tel:112");
+        closeModal();
+        reviewMutation.mutate(
+            { detectionId: selectedDetection.detection_id, body: { review_status: "CONFIRMED_SELF" } },
+            {
+                onSuccess: () => {
+                    setLocalReviewed((prev) => ({ ...prev, [selectedDetection.detection_id]: "CONFIRMED_SELF" }));
+                },
+                onError: () => {
+                    Toast.show({ type: "error", text1: "처리 실패", text2: "다시 시도해주세요.", position: "bottom", visibilityTime: 2500 });
+                },
+            }
+        );
+    };
+
     const handleReview = (status: CctvReviewStatus) => {
         if (!selectedDetection) return;
         closeModal();
@@ -55,15 +73,7 @@ export default function CctvResultScreen() {
             { detectionId: selectedDetection.detection_id, body: { review_status: status } },
             {
                 onSuccess: () => {
-                    setLocalReviewed((prev) => ({ ...prev, [selectedDetection.detection_id]: status }));
-                    if (status === "CONFIRMED_SELF") {
-                        Toast.show({ type: "success", text1: "내 물건으로 확인했어요", position: "bottom", visibilityTime: 2000 });
-                        router.push(ROUTES.MATCHES);
-                    } else if (status === "REJECTED_SELF") {
-                        Toast.show({ type: "success", text1: "도난 의심 신고가 접수됐어요", position: "bottom", visibilityTime: 2500 });
-                    } else {
-                        Toast.show({ type: "info", text1: "나중에 다시 확인할게요", position: "bottom", visibilityTime: 2000 });
-                    }
+                    setRejectedIds((prev) => new Set(prev).add(selectedDetection.detection_id));
                 },
                 onError: () => {
                     Toast.show({ type: "error", text1: "처리 실패", text2: "다시 시도해주세요.", position: "bottom", visibilityTime: 2500 });
@@ -110,7 +120,7 @@ export default function CctvResultScreen() {
                             <Text style={styles.introDesc}>스냅샷을 확인하고 내 물건이 맞는지 알려주세요</Text>
                         </View>
 
-                        {detections.map((det) => {
+                        {detections.filter(d => !rejectedIds.has(d.detection_id)).map((det) => {
                             const reviewed = localReviewed[det.detection_id];
                             const isReviewed = reviewed !== undefined;
                             const scorePercent = Math.round(det.score * 100);
@@ -150,7 +160,7 @@ export default function CctvResultScreen() {
                                             )}
                                         </View>
                                         <View style={[styles.snapshotWrap, { width: SNAPSHOT_WIDTH }]}>
-                                            <Text style={styles.snapshotLabel}>발견 순간</Text>
+                                            <Text style={styles.snapshotLabel}>도난 의심 포착</Text>
                                             {momentSnapshotUri ? (
                                                 <Image source={{ uri: momentSnapshotUri }} style={[styles.snapshot, { width: SNAPSHOT_WIDTH }]} resizeMode="cover" />
                                             ) : (
@@ -186,26 +196,38 @@ export default function CctvResultScreen() {
             <Modal visible={modalType !== null} transparent animationType="fade">
                 <Pressable style={styles.modalOverlay} onPress={closeModal} />
                 <View style={styles.modalWrap}>
-                    <View style={styles.modalCard}>
-                        <Text style={styles.modalTitle}>
-                            {modalType === "confirm" ? "내 물건이 맞나요?" : "내 물건이 아닌가요?"}
-                        </Text>
-                        <Text style={styles.modalDesc}>
-                            {modalType === "confirm" ? "확정하면 매칭 절차가 진행되며,\n취소할 수 없어요."
-                                : "아닌 것으로 표시하면 도난 의심 신고가\n자동 접수돼요."}
-                        </Text>
-                        <TouchableOpacity
-                            style={[styles.modalBtn, modalType === "confirm" ? styles.modalBtnPrimary : styles.modalBtnDanger]}
-                            onPress={() => handleReview(modalType === "confirm" ? "CONFIRMED_SELF" : "REJECTED_SELF")}
-                        >
-                            <Text style={styles.modalBtnText}>
-                                {modalType === "confirm" ? "확정하기" : "신고하기"}
-                            </Text>
-                        </TouchableOpacity>
-                        <TouchableOpacity style={styles.cancelBtn} onPress={closeModal}>
-                            <Text style={styles.cancelBtnText}>취소</Text>
-                        </TouchableOpacity>
-                    </View>
+                    {modalType === "confirm" ? (
+                        <View style={styles.modalCard}>
+                            <View style={styles.policeIconWrap}>
+                                <Phone size={28} color="#ef4444" />
+                            </View>
+                            <Text style={styles.modalTitle}>내 물건이 맞나요?</Text>
+                            <Text style={styles.modalDesc}>{"CCTV에서 해당 물건이 발견됐어요.\n도난이 의심된다면 112에 신고할 수 있어요."}</Text>
+                            <TouchableOpacity
+                                style={[styles.modalBtn, styles.modalBtnDanger]}
+                                onPress={handleConfirmAndCall}
+                            >
+                                <Text style={styles.modalBtnText}>112 신고하기</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity style={styles.cancelBtn} onPress={closeModal}>
+                                <Text style={styles.cancelBtnText}>나중에</Text>
+                            </TouchableOpacity>
+                        </View>
+                    ) : (
+                        <View style={styles.modalCard}>
+                            <Text style={styles.modalTitle}>내 물건이 아닌가요?</Text>
+                            <Text style={styles.modalDesc}>{"아닌 것으로 표시하면 목록에서 제거돼요."}</Text>
+                            <TouchableOpacity
+                                style={[styles.modalBtn, styles.modalBtnDanger]}
+                                onPress={() => handleReview("REJECTED_SELF")}
+                            >
+                                <Text style={styles.modalBtnText}>제거하기</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity style={styles.cancelBtn} onPress={closeModal}>
+                                <Text style={styles.cancelBtnText}>취소</Text>
+                            </TouchableOpacity>
+                        </View>
+                    )}
                 </View>
             </Modal>
         </View>
@@ -268,4 +290,8 @@ const styles = StyleSheet.create({
     modalBtnText: { fontSize: 15, fontFamily: fonts.bold, color: "#fff" },
     cancelBtn: { paddingVertical: 10, alignItems: "center" },
     cancelBtnText: { fontSize: 14, fontFamily: fonts.regular, color: "#aaa" },
+    policeIconWrap: {
+        width: 56, height: 56, borderRadius: 28, backgroundColor: "#fef2f2",
+        alignItems: "center", justifyContent: "center", alignSelf: "center", marginBottom: 4,
+    },
 });

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -1,5 +1,5 @@
 export const BASE_URL =
-  process.env.EXPO_PUBLIC_BASE_URL ?? "https://lalaalal.com";
+    process.env.EXPO_PUBLIC_BASE_URL ?? "https://lalaalal.com";
 
 // Auth
 export const REGISTER_URL = BASE_URL + "/api/auth/device-token";
@@ -37,25 +37,30 @@ export const ITEM_CATEGORIES_URL = BASE_URL + "/api/metadata/item-categories";
 // Images
 export const IMAGE_UPLOAD_URL = BASE_URL + "/api/images/upload";
 
+export const CCTV_DETECTIONS_URL = BASE_URL + "/api/cctv/detections/me";
+export const CCTV_REVIEW_URL = (detectionId: number): string =>
+    BASE_URL + `/api/cctv/detections/${detectionId}/review`;
+
 // App Routes (Navigation)
 export const ROUTES = {
-  HOME: "/",
-  LOGIN: "/(auth)/login",
-  SIGNUP: "/(auth)/signup/email",
-  SIGNUP_VERIFY: "/(auth)/signup/verify",
-  SIGNUP_PASSWORD: "/(auth)/signup/password",
-  SIGNUP_PROFILE: "/(auth)/signup/profile",
-  LOST_ITEM_BOARD: "/(tabs)/lost-item",
-  LOST_ITEM_REGISTER: "/lost-item-register",
-  LOST_ITEM_DETAIL: "/lost-item-detail",
-  CHAT: "/(tabs)/chat",
-  CHAT_ROOM: "/chat-room",
-  MAP: "/(tabs)/map",
-  MYPAGE: "/(tabs)/mypage",
-  SCAN: "/(tabs)/scan",
-  LOADING: "/loading",
-  NOTIFICATION: "/notifications",
-  MATCHES: "/matches",
-  MY_QR: "/my-qr",
-  CCTV_RESULT: "/cctv-result",
+    HOME: "/",
+    LOGIN: "/(auth)/login",
+    SIGNUP: "/(auth)/signup/email",
+    SIGNUP_VERIFY: "/(auth)/signup/verify",
+    SIGNUP_PASSWORD: "/(auth)/signup/password",
+    SIGNUP_PROFILE: "/(auth)/signup/profile",
+    LOST_ITEM_BOARD: "/(tabs)/lost-item",
+    LOST_ITEM_REGISTER: "/lost-item-register",
+    LOST_ITEM_DETAIL: "/lost-item-detail",
+    CHAT: "/(tabs)/chat",
+    CHAT_ROOM: "/chat-room",
+    MAP: "/(tabs)/map",
+    MYPAGE: "/(tabs)/mypage",
+    SCAN: "/(tabs)/scan",
+    LOADING: "/loading",
+    NOTIFICATION: "/notifications",
+    MATCHES: "/matches",
+    MY_QR: "/my-qr",
+    CCTV_RESULT: "/cctv-result",
+    CCTV_ITEMS: "/cctv-items",
 } as const;

--- a/hooks/mutations/useCctvMutations.ts
+++ b/hooks/mutations/useCctvMutations.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { cctvService } from "../../api/services/cctv";
+import { CctvReviewRequest } from "../../api/types";
+import { CCTV_QUERY_KEYS } from "../queries/useCctvQueries";
+
+export const useCctvMutations = {
+    useReviewDetection: (itemId: number) => {
+        const queryClient = useQueryClient();
+        return useMutation({
+            mutationFn: ({
+                             detectionId,
+                             body,
+                         }: {
+                detectionId: number;
+                body: CctvReviewRequest;
+            }) => cctvService.reviewDetection(detectionId, body),
+            onSuccess: () => {
+                queryClient.invalidateQueries({
+                    queryKey: CCTV_QUERY_KEYS.itemDetections(itemId),
+                });
+            },
+        });
+    },
+};

--- a/hooks/queries/useCctvQueries.ts
+++ b/hooks/queries/useCctvQueries.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { cctvService } from "../../api/services/cctv";
+
+export const CCTV_QUERY_KEYS = {
+    myItems: ["cctv", "myItems"] as const,
+    itemDetections: (itemId: number) => ["cctv", "detections", itemId] as const,
+};
+
+export const useCctvQueries = {
+    useMyItems: () =>
+        useQuery({
+            queryKey: CCTV_QUERY_KEYS.myItems,
+            queryFn: () => cctvService.getMyItems(),
+            staleTime: 30_000,
+        }),
+
+    useItemDetections: (itemId: number) =>
+        useQuery({
+            queryKey: CCTV_QUERY_KEYS.itemDetections(itemId),
+            queryFn: () => cctvService.getItemDetections(itemId),
+            staleTime: 0,
+            enabled: !!itemId && !isNaN(itemId),
+        }),
+};

--- a/mocks/cctv.ts
+++ b/mocks/cctv.ts
@@ -1,0 +1,125 @@
+import { CctvDetection, CctvMatchedLostItem } from "@/api/types";
+
+export const mockCctvItems: CctvMatchedLostItem[] = [
+    {
+        lost_item_id: 1,
+        title: "파란 우산",
+        category: "우산",
+        match_count: 3,
+        reported_at: "2026-05-14",
+        image_url: "https://picsum.photos/seed/umbrella/200",
+    },
+    {
+        lost_item_id: 2,
+        title: "에어팟 프로 케이스",
+        category: "전자기기",
+        match_count: 1,
+        reported_at: "2026-05-15",
+        image_url: "https://picsum.photos/seed/airpods/200",
+    },
+    {
+        lost_item_id: 3,
+        title: "갈색 반지갑",
+        category: "지갑/가방",
+        match_count: 5,
+        reported_at: "2026-05-16",
+        image_url: "https://picsum.photos/seed/wallet/200",
+    },
+];
+
+// /api/cctv/detections/me?itemId={id} — 특정 분실물 하나에 대한 CCTV 탐지 상세 목록
+// lost_item_id 기준으로 탐지 건수가 match_count와 일치해야 함
+export const mockCctvDetectionsByItemId: Record<number, CctvDetection[]> = {
+    // lost_item_id: 1 (파란 우산) — match_count: 3
+    1: [
+        {
+            detection_id: 101,
+            score: 0.92,
+            detected_at: "2026-05-15T09:30:00",
+            building_name: "공학관",
+            room_name: "201호",
+            item_snapshot_url: "https://picsum.photos/seed/item101/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment101/400/300",
+        },
+        {
+            detection_id: 102,
+            score: 0.75,
+            detected_at: "2026-05-15T14:20:00",
+            building_name: "도서관",
+            room_name: "1열람실",
+            item_snapshot_url: "https://picsum.photos/seed/item102/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment102/400/300",
+        },
+        {
+            detection_id: 103,
+            score: 0.61,
+            detected_at: "2026-05-16T10:05:00",
+            building_name: "학생회관",
+            room_name: "1층 로비",
+            item_snapshot_url: "https://picsum.photos/seed/item103/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment103/400/300",
+        },
+    ],
+
+    // lost_item_id: 2 (에어팟 프로 케이스) — match_count: 1
+    2: [
+        {
+            detection_id: 201,
+            score: 0.88,
+            detected_at: "2026-05-15T11:45:00",
+            building_name: "인문관",
+            room_name: "세미나실",
+            item_snapshot_url: "https://picsum.photos/seed/item201/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment201/400/300",
+        },
+    ],
+
+    // lost_item_id: 3 (갈색 반지갑) — match_count: 5
+    3: [
+        {
+            detection_id: 301,
+            score: 0.95,
+            detected_at: "2026-05-14T08:10:00",
+            building_name: "중앙도서관",
+            room_name: "2층 열람실",
+            item_snapshot_url: "https://picsum.photos/seed/item301/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment301/400/300",
+        },
+        {
+            detection_id: 302,
+            score: 0.83,
+            detected_at: "2026-05-14T13:30:00",
+            building_name: "공학관",
+            room_name: "302호",
+            item_snapshot_url: "https://picsum.photos/seed/item302/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment302/400/300",
+        },
+        {
+            detection_id: 303,
+            score: 0.71,
+            detected_at: "2026-05-15T09:55:00",
+            building_name: "학생식당",
+            room_name: "1층",
+            item_snapshot_url: "https://picsum.photos/seed/item303/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment303/400/300",
+        },
+        {
+            detection_id: 304,
+            score: 0.65,
+            detected_at: "2026-05-15T16:20:00",
+            building_name: "체육관",
+            room_name: "로비",
+            item_snapshot_url: "https://picsum.photos/seed/item304/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment304/400/300",
+        },
+        {
+            detection_id: 305,
+            score: 0.58,
+            detected_at: "2026-05-16T07:50:00",
+            building_name: "정문",
+            room_name: "경비실 앞",
+            item_snapshot_url: "https://picsum.photos/seed/item305/400/300",
+            moment_snapshot_url: "https://picsum.photos/seed/moment305/400/300",
+        },
+    ],
+};


### PR DESCRIPTION
 작업 내용

     CCTV 탐지 내역 목록 화면 (cctv-items.tsx)
     - 분실물별 CCTV 탐지 결과를 90×90 썸네일 카드 리스트로 표시
     - 카드에 제목, 카테고리 배지, 신고일, 탐지 건수(N건 탐지) 표시
     - 카드 탭 시 해당 분실물의 탐지 상세 화면으로 이동 (itemId 전달)

     CCTV 분석 결과 화면 (cctv-result.tsx)
     - /api/cctv/detections/me?itemId={id} 기반 특정 분실물 탐지 상세 조회
     - 탐지 건별 듀얼 스냅샷(내 물건 / 발견 순간), 유사도 배지, 위치·시간 정보 표시
     - 맞아요 → 112 신고 안내 모달 → "112 신고하기" 탭 시 전화 앱 연결 + CONFIRMED_SELF 서버 전송
     - 아니에요 → REJECTED_SELF 서버 전송 후 해당 카드 목록에서 즉시 제거

     API 레이어 구성
     - api/services/cctv.ts: getMyItems, getItemDetections, reviewDetection 엔드포인트 정의
     - api/types.ts: CctvMatchedLostItem, CctvDetection, CctvMyItemsResponse, CctvItemDetectionsResponse, CctvReviewRequest, CctvReviewStatus 타입 추가
     - hooks/queries/useCctvQueries.ts: useMyItems, useItemDetections React Query 훅
     - hooks/mutations/useCctvMutations.ts: useReviewDetection mutation 훅

     네비게이션 연결
     - 마이페이지 "CCTV 분석" 버튼 → cctv-items 화면으로 진입점 변경
     - app/_layout.tsx에 cctv-items Stack 등록

     Mock 데이터 (mocks/cctv.ts)
     - mockCctvItems: 분실물 3건 (우산/에어팟/지갑, placeholder 이미지 포함)
     - mockCctvDetectionsByItemId: lost_item_id 기준 탐지 목록 — 건수가 match_count와 일치 (3건/1건/5건)
     - USE_MOCK = true 플래그로 mock/실서버 전환 관리, TODO(mock) 주석으로 전환 위치 명시

     스크린샷

     체크리스트

     - 마이페이지 → CCTV 탐지 내역 → 탐지 상세 네비게이션 연결
     - API 레이어 분리 (서비스 / 타입 / 쿼리 훅 / 뮤테이션 훅)
     - Mock 데이터로 UI 검증 완료
     - 실서버 연동 전환 위치 TODO(mock) 주석으로 표시