### PR TITLE
 Feat: CCTV 도난 확정 UI 반영 및 카카오 지도 키 추가

### DIFF
--- a/api/types.ts
+++ b/api/types.ts
@@ -136,7 +136,7 @@ export interface ImageUploadResponse {
 
 // Lost Item Types
 export type ItemType = "LOST" | "FOUND";
-export type ItemStatus = "REPORTED" | "RESOLVED";
+export type ItemStatus = "REPORTED" | "RESOLVED" | "THEFT_CONFIRMED";
 
 export interface ItemPost {
   id: number;

--- a/app/(tabs)/lost-item.tsx
+++ b/app/(tabs)/lost-item.tsx
@@ -3,6 +3,7 @@ import {
   CATEGORY_ICON_MAP,
   CATEGORY_MAP,
   CATEGORY_TO_API,
+  ITEM_STATUS_LABEL,
   ITEM_STATUS_STYLE,
   ITEM_TYPE_MAP,
 } from "@/constants/categories";
@@ -330,10 +331,13 @@ export default function LostItemBoard() {
             }
             renderItem={({ item }) => {
               const korCategory = CATEGORY_MAP[item.category] ?? "기타";
-              const korStatus = ITEM_TYPE_MAP[item.type] ?? item.type;
-              const statusStyle = ITEM_STATUS_STYLE[item.type] ?? {
-                dot: "#aaa",
-              };
+              const isTheftConfirmed = item.status === "THEFT_CONFIRMED";
+              const korStatus = isTheftConfirmed
+                ? ITEM_STATUS_LABEL.THEFT_CONFIRMED
+                : (ITEM_TYPE_MAP[item.type] ?? item.type);
+              const statusStyle = (isTheftConfirmed
+                ? ITEM_STATUS_STYLE.THEFT_CONFIRMED
+                : ITEM_STATUS_STYLE[item.type]) ?? { dot: "#aaa" };
               const IconComponent = CATEGORY_ICON_MAP[item.category] ?? Package;
               const buildingName =
                 BASE_BUILDINGS.find((b) => b.id === item.building_id)?.name ??

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -2,6 +2,7 @@ import { BASE_BUILDINGS } from "@/constants/buildings";
 import {
   CATEGORY_ICON_MAP,
   CATEGORY_MAP,
+  ITEM_STATUS_LABEL,
   ITEM_STATUS_STYLE,
   ITEM_TYPE_MAP,
 } from "@/constants/categories";
@@ -11,6 +12,7 @@ import { useChatMutations } from "@/hooks/mutations/useChatMutations";
 import { useItemQueries } from "@/hooks/queries/useItemQueries";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
+  AlertTriangle,
   ChevronLeft,
   MapPin,
   MessageCircle,
@@ -171,10 +173,10 @@ export default function LostItemDetail() {
 
   const korCategory = CATEGORY_MAP[item.category] ?? "기타";
   const IconComponent = CATEGORY_ICON_MAP[item.category] ?? Package;
-  const statusStyle = ITEM_STATUS_STYLE[item.type] ?? {
-    bg: "#f3f4f6",
-    text: "#888",
-  };
+  const isTheftConfirmed = item.status === "THEFT_CONFIRMED";
+  const statusStyle = (isTheftConfirmed
+    ? ITEM_STATUS_STYLE.THEFT_CONFIRMED
+    : ITEM_STATUS_STYLE[item.type]) ?? { bg: "#f3f4f6", text: "#888" };
   const building = BASE_BUILDINGS.find((b) => b.id === item.building_id);
   const buildingName = building?.name ?? "";
   const detailLocation = item.data_address ?? "";
@@ -227,7 +229,9 @@ export default function LostItemDetail() {
               <Text
                 style={[styles.statusBadgeText, { color: statusStyle.text }]}
               >
-                {ITEM_TYPE_MAP[item.type]}
+                {isTheftConfirmed
+                  ? ITEM_STATUS_LABEL.THEFT_CONFIRMED
+                  : ITEM_TYPE_MAP[item.type]}
               </Text>
             </View>
           </View>
@@ -253,6 +257,15 @@ export default function LostItemDetail() {
               </Text>
             </View>
           </View>
+
+          {isTheftConfirmed && (
+            <View style={styles.theftBanner}>
+              <AlertTriangle size={16} color="#dc2626" />
+              <Text style={styles.theftBannerText}>
+                도난이 확정된 물건입니다. 경찰에 신고되었거나 수사 중일 수 있어요.
+              </Text>
+            </View>
+          )}
 
           {item.description && (
             <View style={styles.descSection}>
@@ -291,7 +304,7 @@ export default function LostItemDetail() {
       </ScrollView>
 
       <View style={[styles.bottomBar, { paddingBottom: insets.bottom + 8 }]}>
-        {item.type === "FOUND" && (
+        {item.type === "FOUND" && !isTheftConfirmed && (
           <TouchableOpacity
             style={styles.matchBtn}
             onPress={handleMatchRequest}
@@ -301,17 +314,19 @@ export default function LostItemDetail() {
           </TouchableOpacity>
         )}
         <TouchableOpacity
-          style={styles.chatBtn}
-          onPress={handleChatPress}
-          activeOpacity={0.85}
-          disabled={createChatRoomMutation.isPending}
+          style={[styles.chatBtn, isTheftConfirmed && styles.chatBtnDisabled]}
+          onPress={isTheftConfirmed ? undefined : handleChatPress}
+          activeOpacity={isTheftConfirmed ? 1 : 0.85}
+          disabled={createChatRoomMutation.isPending || isTheftConfirmed}
         >
           {createChatRoomMutation.isPending ? (
             <ActivityIndicator color="#fff" size="small" />
           ) : (
             <>
               <MessageCircle size={18} color="#fff" />
-              <Text style={styles.chatBtnText}>채팅으로 문의하기</Text>
+              <Text style={styles.chatBtnText}>
+                {isTheftConfirmed ? "도난 확정 처리됨" : "채팅으로 문의하기"}
+              </Text>
             </>
           )}
         </TouchableOpacity>
@@ -527,6 +542,23 @@ const styles = StyleSheet.create({
     elevation: 4,
   },
   chatBtnText: { fontSize: 15, fontFamily: fonts.bold, color: "#fff" },
+  chatBtnDisabled: { backgroundColor: "#f87171", opacity: 0.6 },
+  theftBanner: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    backgroundColor: "#fee2e2",
+    borderRadius: 12,
+    padding: 14,
+    gap: 10,
+    marginBottom: 20,
+  },
+  theftBannerText: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: fonts.regular,
+    color: "#dc2626",
+    lineHeight: 19,
+  },
   shareBtn: {
     width: 50,
     height: 50,

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -37,7 +37,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 
-const KAKAO_API_KEY = process.env.EXPO_PUBLIC_KAKAO_MAP_KEY!;
+const KAKAO_API_KEY = "7488059674373cdf0eb9299fef1ec2ec";
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
 
 function formatDateTime(dateStr: string) {

--- a/constants/categories.ts
+++ b/constants/categories.ts
@@ -49,6 +49,11 @@ export const ITEM_STATUS_STYLE: Record<
 > = {
     LOST: {bg: "#fff7ed", text: "#f97316", dot: "#f97316"},
     FOUND: {bg: "#dcfce7", text: "#16a34a", dot: "#22c55e"},
+    THEFT_CONFIRMED: {bg: "#fee2e2", text: "#dc2626", dot: "#ef4444"},
+};
+
+export const ITEM_STATUS_LABEL: Record<string, string> = {
+    THEFT_CONFIRMED: "도난 확정",
 };
 
 export const CATEGORIES: { label: string; value: string }[] = [


### PR DESCRIPTION
  본문
  ## 개요

  CCTV 리뷰에서 "맞아요(CONFIRMED_SELF)"를 선택하면 백엔드가 item.status를
  THEFT_CONFIRMED로 변경하지만, 기존 프론트엔드는 item.type 기준으로만
  배지를 렌더링하여 게시판·상세 페이지에 도난 확정 여부가 표시되지 않는
  문제를 수정했습니다. 카카오 지도 미표시 문제도 함께 수정합니다.

  ## 변경 사항

  ### Fix: 카카오 지도 키 추가
  - lost-item-detail.tsx에서 EXPO_PUBLIC_KAKAO_MAP_KEY 환경변수가 없어
    지도가 렌더링되지 않던 문제 수정
  - JavaScript 앱 키 직접 적용

  ### Feat: THEFT_CONFIRMED 상태 UI 반영
  - api/types.ts — ItemStatus에 THEFT_CONFIRMED 추가
  - constants/categories.ts — THEFT_CONFIRMED 빨간 스타일 및 ITEM_STATUS_LABEL 상수 추가
  - app/(tabs)/lost-item.tsx — 게시판 목록 카드에서 도난 확정 시 빨간 "도난 확정" 배지 표시
  - app/lost-item-detail.tsx — 도난 확정 시 빨간 배지 + 경고 배너 + 채팅/매칭 버튼 비활성화