### PR TITLE
Fix: 채팅 실시간 버그 수정 및 거래 완료 UI 개선

### DIFF
--- a/api/websocket/chatSocket.ts
+++ b/api/websocket/chatSocket.ts
@@ -71,9 +71,13 @@ class ChatSocketManager {
     onStatus?: StatusHandler,
     onError?: ErrorHandler,
   ) {
-    // 이미 같은 방에 연결 중이면 무시
-    if (this.socket?.readyState === WebSocket.OPEN && this.roomId === roomId)
+    // 이미 같은 방에 연결 중이면 핸들러만 교체하고 소켓 재연결 스킵
+    if (this.socket?.readyState === WebSocket.OPEN && this.roomId === roomId) {
+      this.messageHandler = onMessage;
+      this.statusHandler = onStatus ?? null;
+      this.errorHandler = onError ?? null;
       return;
+    }
 
     this.disconnect();
     this.isManualClose = false;

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -229,7 +229,7 @@ export default function ChatRoomScreen() {
 
   const { data: profile } = useProfile();
   const { data: roomData, isLoading: isRoomLoading } =
-    useChatQueries.useChatRoom(roomIdNum);
+    useChatQueries.useChatRoom(roomIdNum, true);
   const { data: messagesData, isLoading: isMessagesLoading } =
     useChatQueries.useMessages(roomIdNum, false);
 

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -248,10 +248,10 @@ export default function ChatRoomScreen() {
   const reopenChatRoomMutation = useChatMutations.useReopenChatRoom(roomIdNum);
 
   const chatRoom = roomData?.success ? roomData.data : null;
-  const counterpartNickname =
-    profile?.nickname === chatRoom?.owner_nickname
-      ? chatRoom?.finder_nickname
-      : chatRoom?.owner_nickname;
+  const isOwner = profile?.nickname === chatRoom?.owner_nickname;
+  const counterpartNickname = isOwner
+    ? chatRoom?.finder_nickname
+    : chatRoom?.owner_nickname;
   const messages = messagesData?.success ? messagesData.data.messages : [];
   const isClosed = chatRoom?.status !== "OPEN";
   const isLoading = isRoomLoading || isMessagesLoading;
@@ -334,7 +334,9 @@ export default function ChatRoomScreen() {
             type: "success",
             text1:
               reason === "RETURNED"
-                ? "반환 완료 처리되었어요"
+                ? isOwner
+                  ? "반환 완료 처리되었어요"
+                  : "반환 완료로 처리되었어요"
                 : "거래가 종료되었어요",
             position: "bottom",
             visibilityTime: 2500,
@@ -575,7 +577,9 @@ export default function ChatRoomScreen() {
               style={styles.modalBtn}
               onPress={() => handleClose("RETURNED")}
             >
-              <Text style={styles.modalBtnText}>✅ 물건을 돌려받았어요</Text>
+              <Text style={styles.modalBtnText}>
+                {isOwner ? "✅ 물건을 돌려받았어요" : "✅ 물건을 찾아줬어요"}
+              </Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.modalBtn, styles.modalBtnGray]}

--- a/hooks/queries/useChatQueries.ts
+++ b/hooks/queries/useChatQueries.ts
@@ -17,11 +17,12 @@ export const useChatQueries = {
     }),
 
   // 채팅방 상세
-  useChatRoom: (roomId: number) =>
+  useChatRoom: (roomId: number, pollWhileOpen: boolean = false) =>
     useQuery({
       queryKey: CHAT_QUERY_KEYS.room(roomId),
       queryFn: () => chatService.getChatRoom(roomId),
       enabled: !!roomId,
+      refetchInterval: pollWhileOpen ? 3000 : false,
     }),
 
   // 메시지 목록 (포커스 있을 때만 폴링)

--- a/hooks/useChatSocket.ts
+++ b/hooks/useChatSocket.ts
@@ -46,9 +46,15 @@ export function useChatSocket(roomId: number, enabled: boolean = true) {
 
   const isFocusedRef = useRef(false);
   const pendingReadRef = useRef(false);
+  const profileNicknameRef = useRef<string | undefined>(undefined);
   const [status, setStatus] = useState<ConnectionStatus>("DISCONNECTED");
   // isConnected를 React state로 관리 → 연결 상태 변화 시 리렌더링 트리거
   const [isConnected, setIsConnected] = useState(false);
+
+  // profile이 바뀔 때마다 ref 동기화 (onMessage 콜백의 stale closure 방지)
+  useEffect(() => {
+    profileNicknameRef.current = profile?.nickname;
+  }, [profile?.nickname]);
 
   useFocusEffect(
     useCallback(() => {
@@ -80,7 +86,7 @@ export function useChatSocket(roomId: number, enabled: boolean = true) {
             (old) => {
               if (!old?.data) return old;
 
-              const isMine = sender_nickname === profile?.nickname;
+              const isMine = sender_nickname === profileNicknameRef.current;
               if (isMine) return old;
 
               const newMessage: MessageRecord = {


### PR DESCRIPTION

  변경 사항

  1. 상대방 메시지 실시간 미반영 버그 수정
  
  - chatSocket.connect() 에서 이미 연결된 방에 재진입 시 messageHandler를 업데이트하지 않고 early return하던 문제 수정 (api/websocket/chatSocket.ts)
  - useChatSocket 의 onMessage 콜백이 profile.nickname 을 stale closure로 캡처하던 문제 수정 — profileNicknameRef 를 사용해 항상 최신값 참조 (hooks/useChatSocket.ts)

  2. 거래 완료 후 양쪽 채팅방 상태 불일치 수정

  - useChatRoom 쿼리에 pollWhileOpen 옵션 추가, 채팅방 화면에서 3초마다 room 상태 폴링 (hooks/queries/useChatQueries.ts)
  - 한 쪽이 거래 완료를 누르면 최대 3초 이내에 상대방 화면도 동기화

  3. 거래 완료 버튼 텍스트 역할 구분

  - 분실자(owner): "✅ 물건을 돌려받았어요"
  - 습득자(finder): "✅ 물건을 찾아줬어요"
  - isOwner 변수로 역할 판별 로직 정리 (app/chat-room.tsx)

  수정 파일

  - api/websocket/chatSocket.ts
  - hooks/useChatSocket.ts
  - hooks/queries/useChatQueries.ts
  - app/chat-room.tsx







<img width="1080" height="2340" alt="Screenshot_20260517_204314_CapD" src="https://github.com/user-attachments/assets/4f740f0d-aa94-4b2a-8ea7-50e04ec54fb4" />
<img width="1080" height="2280" alt="Screenshot_20260517_204329_CapD" src="https://github.com/user-attachments/assets/e9fc7ded-91a5-4275-8fdd-3496b3cf36ed" />
<img width="1080" height="2340" alt="Screenshot_20260517_213009_CapD" src="https://github.com/user-attachments/assets/47503d42-90d0-4483-bbf6-6e4001617696" />
<img width="1080" height="2280" alt="Screenshot_20260517_213014_CapD" src="https://github.com/user-attachments/assets/58e87638-d1c0-41de-b3a8-c66777c40280" />
<img width="1080" height="2280" alt="Screenshot_20260517_213417_CapD" src="https://github.com/user-attachments/assets/4b72fde7-68b0-476a-9527-b376cf39bfb5" />
<img width="1080" height="2340" alt="Screenshot_20260517_213420_CapD" src="https://github.com/user-attachments/assets/d7737a29-2c3d-4d34-a2fc-469eb37183da" />

1로 뜬거 수정하면서 렌더링된거라 1이 사라지지가 않네요; 
