### PR TITLE
Fix 분실물 게시판·마이페이지 알림 버튼 동작 없음

### DIFF
--- a/app/(tabs)/lost-item.tsx
+++ b/app/(tabs)/lost-item.tsx
@@ -150,7 +150,7 @@ export default function LostItemBoard() {
         <View style={styles.header}>
           <Text style={styles.headerTitle}>분실물 게시판</Text>
           <View style={styles.headerIcons}>
-            <TouchableOpacity style={styles.iconBtn}>
+            <TouchableOpacity style={styles.iconBtn} onPress={() => router.push(ROUTES.NOTIFICATION)}>
               <Bell size={20} color="#444" />
             </TouchableOpacity>
             <TouchableOpacity

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -264,7 +264,7 @@ export default function MapScreen() {
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <Text style={styles.headerTitle}>캠퍼스 지도</Text>
         <View style={styles.headerIcons}>
-          <TouchableOpacity style={styles.iconBtn}>
+          <TouchableOpacity style={styles.iconBtn} onPress={() => router.push(ROUTES.NOTIFICATION)}>
             <Bell size={20} color="#444" />
           </TouchableOpacity>
           <TouchableOpacity

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -98,7 +98,7 @@ export default function MyPageScreen() {
         <Text className="text-xl font-pretendard-bold text-gray-900">
           내 정보
         </Text>
-        <TouchableOpacity className="relative p-2">
+        <TouchableOpacity className="relative p-2" onPress={() => router.push(ROUTES.NOTIFICATION as any)}>
           <Bell size={24} color="#1F2937" />
           {profile && profile.unreadCount > 0 && (
             <View className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white" />

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -29,6 +29,7 @@ type NotificationRecord = {
     | "CHAT_MESSAGE"
     | "ITEM_RETURNED"
     | "THEFT_SUSPECTED"
+    | "CCTV_FOUND"
     | "LOCKER_READY";
   payload: Record<string, any>;
   read_at: string | null;
@@ -40,7 +41,7 @@ const NOTIFICATION_CONFIG = {
     icon: Sparkles,
     label: "매칭 완료",
     message: "분실물과 매칭되었어요! 확인해보세요.",
-    route: ROUTES.LOST_ITEM_BOARD,
+    route: ROUTES.MATCHES,
   },
   CHAT_MESSAGE: {
     icon: MessageCircle,
@@ -59,6 +60,12 @@ const NOTIFICATION_CONFIG = {
     label: "도난 의심",
     message: "물건에 도난 의심 정황이 감지되었어요.",
     route: ROUTES.LOST_ITEM_BOARD,
+  },
+  CCTV_FOUND: {
+    icon: AlertTriangle,
+    label: "CCTV 발견",
+    message: "CCTV에서 내 물건으로 추정되는 영상이 감지되었어요.",
+    route: ROUTES.CCTV_ITEMS,
   },
   LOCKER_READY: {
     icon: Package,


### PR DESCRIPTION
지도 화면 Bell 버튼 수정 시 누락된 두 화면의 알림 버튼을 추가로 수정

 app/(tabs)/lost-item.tsx와 app/(tabs)/mypage.tsx 헤더의 Bell 아이콘 버튼에 onPress 핸들러가 없어 클릭해도 아무 동작 안 함 
같은 패턴으로 app/(tabs)/chat.tsx는 이미 구현되어 있었고, app/(tabs)/map.tsx는 직전 PR에서 수정됐으나 두 화면은 누락


  두 파일 모두 onPress={() => router.push(ROUTES.NOTIFICATION)} 추가

 app/(tabs)/lost-item.tsx
 app/(tabs)/mypage.tsx