### PR TITLE
 Feat: QR 사물함 보관·회수 플로우 완성 및 채팅 거래 완료 UX 개선

### DIFF
--- a/api/services/locker.ts
+++ b/api/services/locker.ts
@@ -1,0 +1,14 @@
+import client from "../client";
+import { ApiResponse } from "../types";
+
+const lockerService = {
+    unlock: (lockerId: number, itemId?: number) =>
+        client.post<ApiResponse<null>>(
+            `/api/lockers/${lockerId}/unlock`,
+            itemId !== undefined ? { itemId } : {},
+        ),
+    lock: (lockerId: number) =>
+        client.post<ApiResponse<null>>(`/api/lockers/${lockerId}/lock`),
+};
+
+export { lockerService };

--- a/api/types.ts
+++ b/api/types.ts
@@ -190,7 +190,7 @@ export interface CreateItemRequest {
 }
 
 export interface CreateItemResponse {
-  itemId: number;
+  item_post_id: number;
   message: string;
   item_status: string;
 }

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -90,24 +90,31 @@ export default function MapScreen() {
   useEffect(() => {
     let subscription: Location.LocationSubscription | null = null;
     (async () => {
-      await Location.requestForegroundPermissionsAsync();
-      const location = await Location.getCurrentPositionAsync({});
-      setUserLocation({
-        lat: location.coords.latitude,
-        lng: location.coords.longitude,
-      });
-      subscription = await Location.watchPositionAsync(
-        {
-          accuracy: Location.Accuracy.High,
-          timeInterval: 3000,
-          distanceInterval: 5,
-        },
-        (loc) =>
-          setUserLocation({
-            lat: loc.coords.latitude,
-            lng: loc.coords.longitude,
-          }),
-      );
+      try {
+        const { status } = await Location.requestForegroundPermissionsAsync();
+        if (status !== "granted") return;
+
+        const location = await Location.getCurrentPositionAsync({});
+        setUserLocation({
+          lat: location.coords.latitude,
+          lng: location.coords.longitude,
+        });
+
+        subscription = await Location.watchPositionAsync(
+          {
+            accuracy: Location.Accuracy.High,
+            timeInterval: 3000,
+            distanceInterval: 5,
+          },
+          (loc) =>
+            setUserLocation({
+              lat: loc.coords.latitude,
+              lng: loc.coords.longitude,
+            }),
+        );
+      } catch (e) {
+        console.warn("[Map] location unavailable", e);
+      }
     })();
     return () => {
       subscription?.remove();

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -1,4 +1,4 @@
-import axiosInstance from "@/api/client";
+import { lockerService } from "@/api/services/locker";
 import { fonts } from "@/constants/typography";
 import { ROUTES } from "@/constants/url";
 import { CameraView, useCameraPermissions } from "expo-camera";
@@ -15,7 +15,7 @@ import {
   User,
   X,
 } from "lucide-react-native";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Alert,
   Linking,
@@ -46,7 +46,16 @@ export default function QRScanScreen() {
   const [modalType, setModalType] = useState<ModalType>(null);
   const [ownerInfo, setOwnerInfo] = useState<OwnerInfo | null>(null);
   const [lockerId, setLockerId] = useState<number | null>(null);
+  const [lockerErrorMsg, setLockerErrorMsg] = useState<string>("");
+  const [lockerReady, setLockerReady] = useState(false);
   const isProcessing = useRef(false);
+
+  useEffect(() => {
+    if (modalType !== "locker_success") return;
+    setLockerReady(false);
+    const t = setTimeout(() => setLockerReady(true), 3000);
+    return () => clearTimeout(t);
+  }, [modalType]);
 
   const handleScanStart = async () => {
     if (!permission?.granted) {
@@ -80,22 +89,12 @@ export default function QRScanScreen() {
         const id = Number(lockerMatch[1]);
         setLockerId(id);
 
-        if (!itemIdParam) {
-          Alert.alert(
-            "물품 정보 없음",
-            "분실물을 먼저 등록하고 '사물함에 넣기'를 선택해주세요.",
-          );
-          isProcessing.current = false;
-          return;
-        }
-
         try {
-          await axiosInstance.post(`/api/lockers/${id}/unlock`, {
-            itemId: Number(itemIdParam),
-          });
+          await lockerService.unlock(id, itemIdParam ? Number(itemIdParam) : undefined);
           setModalType("locker_success");
         } catch (e: any) {
           if (e.response?.status === 403) {
+            setLockerErrorMsg(e.response?.data?.error ?? "권한이 없습니다.");
             setModalType("locker_fail");
           } else {
             const serverMsg: string | undefined = e.response?.data?.error;
@@ -112,12 +111,11 @@ export default function QRScanScreen() {
       if (parsed.type === "locker" && parsed.lockerId) {
         setLockerId(parsed.lockerId);
         try {
-          await axiosInstance.post(`/api/lockers/${parsed.lockerId}/unlock`, {
-            itemId: parsed.itemId ?? null,
-          });
+          await lockerService.unlock(parsed.lockerId, parsed.itemId ?? undefined);
           setModalType("locker_success");
         } catch (e: any) {
           if (e.response?.status === 403) {
+            setLockerErrorMsg(e.response?.data?.error ?? "권한이 없습니다.");
             setModalType("locker_fail");
           } else {
             const serverMsg: string | undefined = e.response?.data?.error;
@@ -194,7 +192,7 @@ export default function QRScanScreen() {
   const handleLockerClose = async () => {
     if (lockerId) {
       try {
-        await axiosInstance.post(`/api/lockers/${lockerId}/lock`);
+        await lockerService.lock(lockerId);
       } catch (e) {
         console.error("사물함 닫기 실패", e);
       }
@@ -379,11 +377,14 @@ export default function QRScanScreen() {
             </View>
             <Text style={styles.modalTitle}>사물함이 열렸어요!</Text>
             <Text style={styles.modalDesc}>
-              물건을 사물함에 넣은 후{"\n"}아래 버튼을 눌러 닫아주세요.
+              {itemIdParam
+                ? `물건을 사물함에 넣은 후\n아래 버튼을 눌러 닫아주세요.`
+                : `물건을 꺼낸 후\n아래 버튼을 눌러 닫아주세요.`}
             </Text>
             <TouchableOpacity
-              style={styles.lockerCloseBtn}
+              style={[styles.lockerCloseBtn, !lockerReady && { opacity: 0.45 }]}
               onPress={handleLockerClose}
+              disabled={!lockerReady}
               activeOpacity={0.85}
             >
               <LinearGradient
@@ -392,7 +393,11 @@ export default function QRScanScreen() {
                 end={{ x: 1, y: 1 }}
                 style={styles.lockerCloseBtnGradient}
               >
-                <Text style={styles.lockerCloseBtnText}>넣었어요, 닫기</Text>
+                <Text style={styles.lockerCloseBtnText}>
+                  {lockerReady
+                    ? (itemIdParam ? "넣었어요, 닫기" : "꺼냈어요, 닫기")
+                    : "사물함 열리는 중..."}
+                </Text>
               </LinearGradient>
             </TouchableOpacity>
           </View>
@@ -415,10 +420,7 @@ export default function QRScanScreen() {
               <X size={32} color="#f87171" />
             </View>
             <Text style={styles.modalTitle}>권한이 없습니다</Text>
-            <Text style={styles.modalDesc}>
-              이 사물함을 열 수 있는 권한이 없어요.{"\n"}
-              물품 소유자 또는 습득자만 접근할 수 있습니다.
-            </Text>
+            <Text style={styles.modalDesc}>{lockerErrorMsg}</Text>
             <TouchableOpacity
               style={styles.closeTextBtn}
               onPress={() => setModalType(null)}

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -73,6 +73,26 @@ export default function QRScanScreen() {
     setIsScanning(false);
 
     try {
+      // 사물함 QR: {baseUrl}/scan/lockers/{id}/unlock
+      const lockerMatch = data.match(/\/lockers\/(\d+)\/unlock/);
+      if (lockerMatch) {
+        const id = Number(lockerMatch[1]);
+        setLockerId(id);
+        console.log("[QR] 사물함 URL QR 감지 lockerId:", id);
+        try {
+          await axiosInstance.post(`/api/lockers/${id}/unlock`);
+          setModalType("locker_success");
+        } catch (e: any) {
+          console.error("[QR] 사물함 열기 실패", e.response?.status, e.message);
+          if (e.response?.status === 403) {
+            setModalType("locker_fail");
+          } else {
+            Alert.alert("오류", "사물함 열기에 실패했어요.");
+          }
+        }
+        return;
+      }
+
       const parsed = JSON.parse(data);
 
       // 사물함 QR

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -362,7 +362,7 @@ export default function QRScanScreen() {
         </View>
       </Modal>
 
-      {/* 보관완료 모달 */}
+      {/* 사물함 열림 모달 — 물건 넣은 후 닫기 */}
       <Modal
         visible={modalType === "locker_success"}
         transparent
@@ -370,16 +370,16 @@ export default function QRScanScreen() {
       >
         <Pressable
           style={styles.modalOverlay}
-          onPress={() => setModalType(null)}
+          onPress={() => {}}
         />
         <View style={styles.modalWrap}>
           <View style={styles.modalCard}>
             <View style={styles.successIconWrap}>
               <Archive size={32} color="#fff" />
             </View>
-            <Text style={styles.modalTitle}>보관 완료!</Text>
+            <Text style={styles.modalTitle}>사물함이 열렸어요!</Text>
             <Text style={styles.modalDesc}>
-              물건이 사물함에 안전하게 보관되었어요.
+              물건을 사물함에 넣은 후{"\n"}아래 버튼을 눌러 닫아주세요.
             </Text>
             <TouchableOpacity
               style={styles.lockerCloseBtn}
@@ -392,7 +392,7 @@ export default function QRScanScreen() {
                 end={{ x: 1, y: 1 }}
                 style={styles.lockerCloseBtnGradient}
               >
-                <Text style={styles.lockerCloseBtnText}>사물함 닫기</Text>
+                <Text style={styles.lockerCloseBtnText}>넣었어요, 닫기</Text>
               </LinearGradient>
             </TouchableOpacity>
           </View>

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -4,7 +4,7 @@ import { ROUTES } from "@/constants/url";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import * as ImagePicker from "expo-image-picker";
 import { LinearGradient } from "expo-linear-gradient";
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import {
   Archive,
   Bell,
@@ -40,6 +40,7 @@ type OwnerInfo = {
 export default function QRScanScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const { itemId: itemIdParam } = useLocalSearchParams<{ itemId?: string }>();
   const [permission, requestPermission] = useCameraPermissions();
   const [isScanning, setIsScanning] = useState(false);
   const [modalType, setModalType] = useState<ModalType>(null);
@@ -78,16 +79,27 @@ export default function QRScanScreen() {
       if (lockerMatch) {
         const id = Number(lockerMatch[1]);
         setLockerId(id);
-        console.log("[QR] 사물함 URL QR 감지 lockerId:", id);
+
+        if (!itemIdParam) {
+          Alert.alert(
+            "물품 정보 없음",
+            "분실물을 먼저 등록하고 '사물함에 넣기'를 선택해주세요.",
+          );
+          isProcessing.current = false;
+          return;
+        }
+
         try {
-          await axiosInstance.post(`/api/lockers/${id}/unlock`);
+          await axiosInstance.post(`/api/lockers/${id}/unlock`, {
+            itemId: Number(itemIdParam),
+          });
           setModalType("locker_success");
         } catch (e: any) {
-          console.error("[QR] 사물함 열기 실패", e.response?.status, e.message);
           if (e.response?.status === 403) {
             setModalType("locker_fail");
           } else {
-            Alert.alert("오류", "사물함 열기에 실패했어요.");
+            const serverMsg: string | undefined = e.response?.data?.error;
+            Alert.alert("오류", serverMsg ?? "사물함 열기에 실패했어요.");
           }
         }
         return;
@@ -108,7 +120,8 @@ export default function QRScanScreen() {
           if (e.response?.status === 403) {
             setModalType("locker_fail");
           } else {
-            Alert.alert("오류", "사물함 열기에 실패했어요.");
+            const serverMsg: string | undefined = e.response?.data?.error;
+            Alert.alert("오류", serverMsg ?? "사물함 열기에 실패했어요.");
           }
         }
       }
@@ -188,6 +201,9 @@ export default function QRScanScreen() {
     }
     setModalType(null);
     setLockerId(null);
+    if (itemIdParam) {
+      router.replace(`${ROUTES.LOST_ITEM_DETAIL}?id=${itemIdParam}` as any);
+    }
   };
 
   // 카메라 스캔 화면

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -326,21 +326,29 @@ export default function ChatRoomScreen() {
   ]);
 
   const handleClose = useCallback(
-    (reason: "RETURNED" | "ABANDONED") => {
+    (reason: "RETURNED" | "ABANDONED", navigateToScan = false) => {
       setShowCloseModal(false);
       closeChatRoomMutation.mutate(reason, {
         onSuccess: () => {
-          Toast.show({
-            type: "success",
-            text1:
-              reason === "RETURNED"
-                ? isOwner
-                  ? "반환 완료 처리되었어요"
-                  : "반환 완료로 처리되었어요"
-                : "거래가 종료되었어요",
-            position: "bottom",
-            visibilityTime: 2500,
-          });
+          if (reason === "RETURNED" && navigateToScan) {
+            Toast.show({
+              type: "success",
+              text1: "수령 완료! 사물함 QR을 스캔해서 물건을 꺼내주세요.",
+              position: "bottom",
+              visibilityTime: 3000,
+            });
+            router.replace("/(tabs)/scan" as any);
+          } else {
+            Toast.show({
+              type: "success",
+              text1:
+                reason === "RETURNED"
+                  ? "거래가 완료되었어요"
+                  : "거래가 종료되었어요",
+              position: "bottom",
+              visibilityTime: 2500,
+            });
+          }
         },
         onError: () => {
           Toast.show({
@@ -573,14 +581,29 @@ export default function ChatRoomScreen() {
           <View style={styles.modalCard}>
             <Text style={styles.modalTitle}>거래 종료</Text>
             <Text style={styles.modalDesc}>거래를 어떻게 종료할까요?</Text>
-            <TouchableOpacity
-              style={styles.modalBtn}
-              onPress={() => handleClose("RETURNED")}
-            >
-              <Text style={styles.modalBtnText}>
-                {isOwner ? "✅ 물건을 돌려받았어요" : "✅ 물건을 찾아줬어요"}
-              </Text>
-            </TouchableOpacity>
+            {isOwner ? (
+              <>
+                <TouchableOpacity
+                  style={styles.modalBtn}
+                  onPress={() => handleClose("RETURNED", true)}
+                >
+                  <Text style={styles.modalBtnText}>📦 사물함에서 물건을 꺼낼게요</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.modalBtn}
+                  onPress={() => handleClose("RETURNED", false)}
+                >
+                  <Text style={styles.modalBtnText}>🤝 직접 물건을 받았어요</Text>
+                </TouchableOpacity>
+              </>
+            ) : (
+              <TouchableOpacity
+                style={styles.modalBtn}
+                onPress={() => handleClose("RETURNED")}
+              >
+                <Text style={styles.modalBtnText}>✅ 물건을 찾아줬어요</Text>
+              </TouchableOpacity>
+            )}
             <TouchableOpacity
               style={[styles.modalBtn, styles.modalBtnGray]}
               onPress={() => handleClose("ABANDONED")}

--- a/app/lost-item-register.tsx
+++ b/app/lost-item-register.tsx
@@ -95,6 +95,8 @@ export default function LostItemRegister() {
     const [showBuildingSheet, setShowBuildingSheet] = useState(false);
     const [showRoomSheet, setShowRoomSheet] = useState(false);
 
+    const [showDeliveryModal, setShowDeliveryModal] = useState(false);
+
     const createItemMutation = useItemMutations.useCreateItem();
 
     // 시간표 fetch
@@ -219,22 +221,26 @@ export default function LostItemRegister() {
         return e;
     };
 
-    const handleSubmit = async () => {
+    const handleSubmit = () => {
         const e = validate();
         if (Object.keys(e).length > 0) { setErrors(e); return; }
         setErrors({});
 
+        if (type === "FOUND") {
+            setShowDeliveryModal(true);
+            return;
+        }
+
+        doSubmit("direct");
+    };
+
+    const doSubmit = async (deliveryChoice: "direct" | "locker") => {
         let building_id: number;
         let detail_address: string;
 
-        if (type === "LOST") {
-            if (hasTimetable) {
-                building_id = matchedCourse!.buildingId;
-                detail_address = matchedCourse!.roomName;
-            } else {
-                building_id = selectedBuildingId!;
-                detail_address = selectedRoomName;
-            }
+        if (type === "LOST" && hasTimetable) {
+            building_id = matchedCourse!.buildingId;
+            detail_address = matchedCourse!.roomName;
         } else {
             building_id = selectedBuildingId!;
             detail_address = selectedRoomName;
@@ -265,12 +271,20 @@ export default function LostItemRegister() {
                 },
                 {
                     onSuccess: (result) => {
-                        if (result.success) {
-                            const itemId = result.data?.itemId;
+                        const itemId = result.data?.item_post_id;
+                        if (deliveryChoice === "locker") {
+                            if (!itemId) {
+                                Alert.alert(
+                                    "등록 완료",
+                                    "게시물이 등록됐어요. 서버에서 게시글 ID를 받지 못했습니다. 게시판에서 확인해주세요.",
+                                    [{ text: "확인", onPress: () => router.back() }],
+                                );
+                                return;
+                            }
+                            router.push(`${ROUTES.SCAN}?itemId=${itemId}` as any);
+                        } else {
                             if (itemId) router.replace(`${ROUTES.LOST_ITEM_DETAIL}?id=${itemId}`);
                             else router.back();
-                        } else {
-                            Alert.alert("등록 실패", result.error ?? "다시 시도해주세요.");
                         }
                     },
                     onError: () => Alert.alert("오류", "네트워크 오류가 발생했어요."),
@@ -703,6 +717,41 @@ export default function LostItemRegister() {
                     }}
                 />
             )}
+
+            {/* 전달 방법 선택 모달 */}
+            <Modal visible={showDeliveryModal} transparent animationType="fade">
+                <Pressable style={styles.modalOverlay} onPress={() => setShowDeliveryModal(false)} />
+                <View style={styles.deliveryModalWrap}>
+                    <View style={styles.deliveryModalCard}>
+                        <Text style={styles.deliveryModalTitle}>전달 방법 선택</Text>
+                        <Text style={styles.deliveryModalDesc}>
+                            물건을 어떻게 전달하시겠어요?
+                        </Text>
+                        <TouchableOpacity
+                            style={styles.deliveryPrimaryBtn}
+                            disabled={createItemMutation.isPending}
+                            onPress={() => {
+                                setShowDeliveryModal(false);
+                                doSubmit("direct");
+                            }}
+                        >
+                            <Text style={styles.deliveryBtnText}>
+                                {createItemMutation.isPending ? "등록 중..." : "직접 전달하기"}
+                            </Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                            style={styles.deliverySecondaryBtn}
+                            disabled={createItemMutation.isPending}
+                            onPress={() => {
+                                setShowDeliveryModal(false);
+                                doSubmit("locker");
+                            }}
+                        >
+                            <Text style={[styles.deliveryBtnText, { color: "#6366f1" }]}>사물함에 넣기</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </Modal>
         </View>
     );
 }
@@ -837,4 +886,27 @@ const styles = StyleSheet.create({
     sheetItemText: { fontSize: 14, fontFamily: fonts.regular, color: "#444" },
     sheetItemTextActive: { color: "#6366f1", fontFamily: fonts.bold },
     sheetItemCheck: { fontSize: 14, color: "#6366f1", fontFamily: fonts.bold },
+    deliveryModalWrap: {
+        position: "absolute", top: 0, left: 0, right: 0, bottom: 0,
+        alignItems: "center", justifyContent: "center", paddingHorizontal: 32,
+    },
+    deliveryModalCard: {
+        width: "100%", backgroundColor: "#fff", borderRadius: 20,
+        padding: 24, gap: 12,
+        shadowColor: "#000", shadowOpacity: 0.1, shadowRadius: 16, elevation: 8,
+    },
+    deliveryModalTitle: { fontSize: 17, fontFamily: fonts.bold, color: "#111", textAlign: "center" },
+    deliveryModalDesc: {
+        fontSize: 13, fontFamily: fonts.regular, color: "#666",
+        textAlign: "center", lineHeight: 19,
+    },
+    deliveryPrimaryBtn: {
+        backgroundColor: "#6366f1", borderRadius: 12, paddingVertical: 14,
+        alignItems: "center", marginTop: 4,
+    },
+    deliverySecondaryBtn: {
+        borderWidth: 1.5, borderColor: "#e5e7eb", borderRadius: 12,
+        paddingVertical: 14, alignItems: "center",
+    },
+    deliveryBtnText: { fontSize: 15, fontFamily: fonts.bold, color: "#fff" },
 });

--- a/hooks/mutations/useLockerMutations.ts
+++ b/hooks/mutations/useLockerMutations.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+import { lockerService } from "@/api/services/locker";
+
+export const useLockerMutations = {
+    useUnlockLocker: () =>
+        useMutation({
+            mutationFn: ({ lockerId, itemId }: { lockerId: number; itemId?: number }) =>
+                lockerService.unlock(lockerId, itemId),
+        }),
+    useLockLocker: () =>
+        useMutation({
+            mutationFn: (lockerId: number) => lockerService.lock(lockerId),
+        }),
+};


### PR DESCRIPTION
 ---
  변경 내용

  🆕 신규 파일

  - api/services/locker.ts — 사물함 unlock/lock API 서비스 레이어 추가 (CLAUDE.md 규칙: tsx에서 직접 axios 호출 금지)
  - hooks/mutations/useLockerMutations.ts — useUnlockLocker / useLockLocker TanStack Query 뮤테이션 훅

  사물함 보관 플로우 (app/(tabs)/scan.tsx)

  - axiosInstance 직접 호출 → lockerService 사용으로 교체
  - unlock 성공 후 3초간 "닫기" 버튼 비활성화 ("사물함 열리는 중...") → 아두이노가 물리적으로 열릴 시간 확보 후 명령 충돌 방지
  - 403 에러 시 하드코딩 문자열 대신 서버 에러 메시지를 그대로 표시

   사물함 회수 플로우 (app/(tabs)/scan.tsx)

  - !itemIdParam 가드 제거 → itemId 없이도 QR 스캔 가능 (회수 모드)
  - itemId 있음 → body { itemId } (보관), itemId 없음 → body {} (회수), 서버가 권한 판단
  - 모달 텍스트 분기: "물건을 넣은 후 닫기" / "물건을 꺼낸 후 닫기"

   채팅 거래 완료 UX (app/chat-room.tsx)

  - "거래 완료" 모달 버튼 재설계
    - 물건 주인: "📦 사물함에서 물건을 꺼낼게요" (RETURNED → 스캔 탭 이동) / "🤝 직접 물건을 받았어요" (RETURNED → 완료 토스트)
    - 습득자: "✅ 물건을 찾아줬어요" (RETURNED → 완료 토스트)
  - 사물함 선택 시 close API 성공 후(onSuccess) 스캔 탭으로 이동 → API 호출 순서 보장

  지도 위치 오류 수정 (app/(tabs)/map.tsx)

  - requestForegroundPermissionsAsync 결과 미확인으로 발생하던 Uncaught (in promise) 에러 수정
  - 위치 서비스 꺼짐·권한 거부 시 앱 크래시 없이 기본 위치로 지도 표시

  분실물 등록 UX (app/lost-item-register.tsx)

  - 모달 선택(보관 vs 대면) → API 호출 순서로 변경 (기존: API 호출 후 모달)
  - CreateItemResponse.item_post_id 필드명 오타 수정 (itemId → item_post_id)

실제 기기랑 연동 잘 되는거 확인 
QR 스캔은 http://도메인:8080/scan/lockers/1/unlock 이런식으로 구성해서 테스트 했음 