### PR TITLE
QR 스캔 및 채팅 연결 기능

### DIFF
--- a/api/services/chat.ts
+++ b/api/services/chat.ts
@@ -3,6 +3,7 @@ import {
     ApiResponse,
     ChatRoomRecord,
     CloseChatRoomRequest,
+    CreateChatRoomByOwnerRequest,
     CreateChatRoomRequest,
     CreateChatRoomResult,
     FindChatRoomResult,
@@ -40,6 +41,14 @@ export const chatService = {
     const res = await client.post<ApiResponse<CreateChatRoomResult>>(
       "/api/chat-rooms/create",
       data,
+    );
+    return res.data;
+  },
+
+  createChatRoomByOwner: async (data: CreateChatRoomByOwnerRequest) => {
+    const res = await client.post<ApiResponse<CreateChatRoomResult>>(
+      "/api/chat-rooms/by-owner",
+      data
     );
     return res.data;
   },

--- a/api/services/item.ts
+++ b/api/services/item.ts
@@ -3,9 +3,9 @@ import {
     ApiResponse,
     CreateItemRequest,
     CreateItemResponse,
-    ItemDetail,
     ItemFilter,
     ItemListResponse,
+    ItemPost,
 } from "../types";
 import {
     ITEMS_CREATE_URL,
@@ -23,8 +23,8 @@ export const itemService = {
         return response.data;
     },
 
-    getItemDetail: async (id: number | string) => {
-        const response = await axiosInstance.get<ApiResponse<ItemDetail>>(
+    getItemPost: async (id: number | string) => {
+        const response = await axiosInstance.get<ApiResponse<ItemPost>>(
             `${ITEMS_LIST_URL}/${id}`, // Swagger docs: /api/items/post/list/{id}
         );
         return response.data;

--- a/api/services/user.ts
+++ b/api/services/user.ts
@@ -1,5 +1,5 @@
 import axiosInstance from "../client";
-import {UserProfile, UpdateProfileRequest} from "../types";
+import {UserProfile, UpdateProfileRequest, ScanOwnerResult, ApiResponse} from "../types";
 import {PROFILE_ME_URL, USER_ACCOUNT_URL} from "@/constants/url";
 
 export const userService = {
@@ -20,4 +20,9 @@ export const userService = {
         const response = await axiosInstance.delete<void>(USER_ACCOUNT_URL);
         return response.data;
     },
+
+    scanQrCode: async (url: string) => {
+      const response = await axiosInstance.get<ApiResponse<ScanOwnerResult>>(url);
+      return response.data;
+    }
 };

--- a/api/types.ts
+++ b/api/types.ts
@@ -60,6 +60,11 @@ export interface UserProfile {
   unreadCount: number;
 }
 
+export interface ScanOwnerResult {
+  owner_id: number;
+  nickname: string;
+}
+
 export interface UpdateProfileRequest {
   nickname: string;
   department: string;
@@ -220,7 +225,7 @@ export interface ChatRoomRecord {
   owner_nickname: string;
   finder_nickname: string;
   item_name: string;
-  item_id?: number;
+  item_id: number;
 }
 
 export interface MessageRecord {
@@ -239,6 +244,10 @@ export interface ListMessagesResult {
 export interface CreateChatRoomRequest {
   item_id: number | null;
   counterpart_id: number;
+}
+
+export interface CreateChatRoomByOwnerRequest {
+  owner_id: number;
 }
 
 export interface CreateChatRoomResult {

--- a/api/types.ts
+++ b/api/types.ts
@@ -165,6 +165,7 @@ export interface ItemPost {
   id: number;
   title: string;
   description: string;
+  item_id: number;
   type: ItemType;
   status: string;
   category: string;
@@ -180,8 +181,6 @@ export interface ItemListResponse {
   page: number;
   item_posts: ItemPost[];
 }
-
-export interface ItemDetail extends ItemPost {}
 
 export interface ItemFilter {
   status?: string;

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -1,11 +1,9 @@
-import { chatService } from "@/api/services/chat";
 import { lockerService } from "@/api/services/locker";
 import { userService } from "@/api/services/user";
 import { ApiResponse, CreateChatRoomResult, ScanOwnerResult } from "@/api/types";
 import { fonts } from "@/constants/typography";
 import { ROUTES } from "@/constants/url";
 import { useChatMutations } from "@/hooks/mutations/useChatMutations";
-import { scanQrCode } from "@/hooks/queries/useUserQueries";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import * as ImagePicker from "expo-image-picker";
 import { LinearGradient } from "expo-linear-gradient";

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -1,6 +1,11 @@
+import { chatService } from "@/api/services/chat";
 import { lockerService } from "@/api/services/locker";
+import { userService } from "@/api/services/user";
+import { ApiResponse, CreateChatRoomResult, ScanOwnerResult } from "@/api/types";
 import { fonts } from "@/constants/typography";
 import { ROUTES } from "@/constants/url";
+import { useChatMutations } from "@/hooks/mutations/useChatMutations";
+import { scanQrCode } from "@/hooks/queries/useUserQueries";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import * as ImagePicker from "expo-image-picker";
 import { LinearGradient } from "expo-linear-gradient";
@@ -32,9 +37,7 @@ type ModalType = "owner" | "locker_success" | "locker_fail" | null;
 
 type OwnerInfo = {
   nickname: string;
-  department: string;
-  itemName: string;
-  itemId?: number;
+  ownerId: number;
 };
 
 export default function QRScanScreen() {
@@ -49,6 +52,8 @@ export default function QRScanScreen() {
   const [lockerErrorMsg, setLockerErrorMsg] = useState<string>("");
   const [lockerReady, setLockerReady] = useState(false);
   const isProcessing = useRef(false);
+
+  const createChatRoomByOwnerMutation = useChatMutations.useCreateChatRoomByOwner();
 
   useEffect(() => {
     if (modalType !== "locker_success") return;
@@ -103,6 +108,16 @@ export default function QRScanScreen() {
         }
         return;
       }
+      const userMatch = data.match(/\/scan\/owner\/(\d+)/)
+      if (userMatch) {
+        const response: ApiResponse<ScanOwnerResult> = await userService.scanQrCode(data);
+        setOwnerInfo({
+          ownerId: response.data.owner_id,
+          nickname: response.data.nickname,
+        });
+        setModalType('owner');
+        return;
+      }
 
       const parsed = JSON.parse(data);
 
@@ -125,15 +140,7 @@ export default function QRScanScreen() {
       }
       // 물건 QR (ownerQR)
       // TODO: 백엔드 QR 데이터 형태 확인 후 조건 수정
-      else if (parsed.type === "item") {
-        setOwnerInfo({
-          nickname: parsed.nickname ?? "알 수 없음",
-          department: parsed.department ?? "",
-          itemName: parsed.itemName ?? "물건",
-          itemId: parsed.itemId,
-        });
-        setModalType("owner");
-      } else {
+      else {
         Alert.alert("알 수 없는 QR", "인식할 수 없는 QR 코드예요.");
       }
     } catch {
@@ -159,8 +166,7 @@ export default function QRScanScreen() {
         onPress: () => {
           setOwnerInfo({
             nickname: "김민준",
-            department: "컴퓨터공학과",
-            itemName: "학생증",
+            ownerId: 1
           });
           setModalType("owner");
         },
@@ -177,15 +183,20 @@ export default function QRScanScreen() {
     ]);
   };
 
-  const handleChat = () => {
+  const handleChat = async () => {
     setModalType(null);
-    if (ownerInfo?.itemId) {
-      router.push({
-        pathname: ROUTES.CHAT_ROOM,
-        params: { itemId: ownerInfo.itemId },
-      } as any);
-    } else {
-      router.push(ROUTES.CHAT as any);
+    if (ownerInfo) {
+      createChatRoomByOwnerMutation.mutate({
+        owner_id: ownerInfo.ownerId
+      }, {
+        onSuccess: (response: ApiResponse<CreateChatRoomResult>) => {
+          const roomId: number = response.data.room_data.room_id;
+          router.push({
+            pathname: ROUTES.CHAT_ROOM,
+            params: { roomId }
+          });
+        }
+      });
     }
   };
 
@@ -327,13 +338,8 @@ export default function QRScanScreen() {
               <User size={32} color="#aaa" />
             </View>
             <Text style={styles.ownerName}>{ownerInfo?.nickname}</Text>
-            <Text style={styles.ownerDept}>{ownerInfo?.department}</Text>
             <Text style={styles.ownerDesc}>
-              {ownerInfo?.nickname}님의 잃어버린 물건{" "}
-              <Text style={styles.ownerItem}>
-                &ldquo;{ownerInfo?.itemName}&rdquo;
-              </Text>{" "}
-              을(를) 찾으셨나요?
+              {ownerInfo?.nickname}님의 잃어버린 물건을 찾으셨나요?
             </Text>
             <TouchableOpacity
               style={styles.chatBtn}

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -1,6 +1,7 @@
 import { ApiResponse, ListMessagesResult, MessageRecord } from "@/api/types";
 import { ConnectionStatus } from "@/api/websocket/chatSocket";
 import { fonts } from "@/constants/typography";
+import { ROUTES } from "@/constants/url";
 import { useChatMutations } from "@/hooks/mutations/useChatMutations";
 import {
   CHAT_QUERY_KEYS,
@@ -325,6 +326,19 @@ export default function ChatRoomScreen() {
     sendMessageMutation,
   ]);
 
+  const handleOpenLocker = useCallback(
+    () => {
+      setShowCloseModal(false);
+      const itemId = chatRoom?.item_id;
+      if (itemId) {
+        router.replace({
+          pathname: ROUTES.SCAN,
+          params: { itemId: itemId }
+        });
+      }
+    }, []
+  );
+
   const handleClose = useCallback(
     (reason: "RETURNED" | "ABANDONED", navigateToScan = false) => {
       setShowCloseModal(false);
@@ -597,12 +611,20 @@ export default function ChatRoomScreen() {
                 </TouchableOpacity>
               </>
             ) : (
-              <TouchableOpacity
-                style={styles.modalBtn}
-                onPress={() => handleClose("RETURNED")}
-              >
-                <Text style={styles.modalBtnText}>✅ 물건을 찾아줬어요</Text>
-              </TouchableOpacity>
+              <>
+                <TouchableOpacity
+                  style={styles.modalBtn}
+                  onPress={() => handleOpenLocker()}
+                >
+                  <Text style={styles.modalBtnText}>📦 사물함에서 물건을 넣을게요</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.modalBtn}
+                  onPress={() => handleClose("RETURNED")}
+                >
+                  <Text style={styles.modalBtnText}>✅ 물건을 찾아줬어요</Text>
+                </TouchableOpacity>
+              </>
             )}
             <TouchableOpacity
               style={[styles.modalBtn, styles.modalBtnGray]}

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -616,7 +616,7 @@ export default function ChatRoomScreen() {
                   style={styles.modalBtn}
                   onPress={() => handleOpenLocker()}
                 >
-                  <Text style={styles.modalBtnText}>📦 사물함에서 물건을 넣을게요</Text>
+                  <Text style={styles.modalBtnText}>📦 사물함에 물건을 넣을게요</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={styles.modalBtn}

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -60,29 +60,29 @@ export default function LostItemDetail() {
   const { data: buildingsRes } = useMetadataQueries.useBuildings();
   const apiBuildings = buildingsRes?.data?.data ?? [];
 
-  const item = response?.success ? response.data : null;
+  const itemPost = response?.success ? response.data : null;
 
-  const imageUrl = item?.image_url
-    ? item.image_url.startsWith("http")
-      ? item.image_url
-      : `${BASE_URL}${item.image_url}`
+  const imageUrl = itemPost?.image_url
+    ? itemPost.image_url.startsWith("http")
+      ? itemPost.image_url
+      : `${BASE_URL}${itemPost.image_url}`
     : null;
 
   // 채팅 버튼 클릭 핸들러 (테스트용 ID 하드코딩)
   const handleChatPress = useCallback(() => {
-    if (!item) return;
+    if (!itemPost) return;
 
-    console.log("reporter_id:", item.reporter_id); // 추가!
+    console.log("reporter_id:", itemPost.reporter_id); // 추가!
     console.log("=== 채팅 생성 테스트 시작 ===");
-    console.log("아이템 ID:", item.id);
+    console.log("아이템 ID:", itemPost.item_id);
 
     createChatRoomMutation.mutate(
       {
-        item_id: item.id,
+        item_id: itemPost.item_id,
         // 테스트를 위해 에뮬레이터 계정 ID를 1로 가정하고 하드코딩합니다.
         //counterpart_id: 1,
         // reporter_id 추가되면
-        counterpart_id: item.reporter_id ?? 0,
+        counterpart_id: itemPost.reporter_id ?? 0,
       },
       {
         onSuccess: (res) => {
@@ -105,18 +105,18 @@ export default function LostItemDetail() {
         },
       },
     );
-  }, [item, createChatRoomMutation, router]);
+  }, [itemPost, createChatRoomMutation, router]);
 
   const handleShare = async () => {
-    if (!item) return;
+    if (!itemPost) return;
     const sharedBuildingName =
-      apiBuildings.find((b) => b.id === item.building_id)?.name ?? "";
-    const locationText = item.data_address
-      ? `${sharedBuildingName} · ${item.data_address}`
+      apiBuildings.find((b) => b.id === itemPost.building_id)?.name ?? "";
+    const locationText = itemPost.data_address
+      ? `${sharedBuildingName} · ${itemPost.data_address}`
       : sharedBuildingName;
     try {
       await Share.share({
-        message: `[줍픽] ${item.title ?? "분실물"} - ${locationText}`,
+        message: `[줍픽] ${itemPost.title ?? "분실물"} - ${locationText}`,
       });
     } catch {
       Alert.alert("공유 실패");
@@ -152,7 +152,7 @@ export default function LostItemDetail() {
     );
   }
 
-  if (!item) {
+  if (!itemPost) {
     return (
       <View
         style={[
@@ -175,15 +175,15 @@ export default function LostItemDetail() {
     );
   }
 
-  const korCategory = CATEGORY_MAP[item.category] ?? "기타";
-  const IconComponent = CATEGORY_ICON_MAP[item.category] ?? Package;
-  const isTheftConfirmed = item.status === "THEFT_CONFIRMED";
+  const korCategory = CATEGORY_MAP[itemPost.category] ?? "기타";
+  const IconComponent = CATEGORY_ICON_MAP[itemPost.category] ?? Package;
+  const isTheftConfirmed = itemPost.status === "THEFT_CONFIRMED";
   const statusStyle = (isTheftConfirmed
     ? ITEM_STATUS_STYLE.THEFT_CONFIRMED
-    : ITEM_STATUS_STYLE[item.type]) ?? { bg: "#f3f4f6", text: "#888" };
+    : ITEM_STATUS_STYLE[itemPost.type]) ?? { bg: "#f3f4f6", text: "#888" };
   const buildingName =
-    apiBuildings.find((b) => b.id === item.building_id)?.name ?? "";
-  const detailLocation = item.data_address ?? "";
+    apiBuildings.find((b) => b.id === itemPost.building_id)?.name ?? "";
+  const detailLocation = itemPost.data_address ?? "";
   const coordBuilding = BASE_BUILDINGS.find((b) => b.name === buildingName);
   const lat = coordBuilding?.lat;
   const lng = coordBuilding?.lng;
@@ -236,12 +236,12 @@ export default function LostItemDetail() {
               >
                 {isTheftConfirmed
                   ? ITEM_STATUS_LABEL.THEFT_CONFIRMED
-                  : ITEM_TYPE_MAP[item.type]}
+                  : ITEM_TYPE_MAP[itemPost.type]}
               </Text>
             </View>
           </View>
 
-          <Text style={styles.title}>{item.title ?? "제목 없음"}</Text>
+          <Text style={styles.title}>{itemPost.title ?? "제목 없음"}</Text>
 
           <View style={styles.locationCard}>
             <View style={styles.locationIconWrap}>
@@ -255,10 +255,10 @@ export default function LostItemDetail() {
             </View>
             <View style={styles.locationTimeWrap}>
               <Text style={styles.locationTimeLabel}>
-                {item.type === "FOUND" ? "습득" : "분실"}
+                {itemPost.type === "FOUND" ? "습득" : "분실"}
               </Text>
               <Text style={styles.locationTime}>
-                {formatDateTime(item.created_at)}
+                {formatDateTime(itemPost.created_at)}
               </Text>
             </View>
           </View>
@@ -272,10 +272,10 @@ export default function LostItemDetail() {
             </View>
           )}
 
-          {item.description && (
+          {itemPost.description && (
             <View style={styles.descSection}>
               <Text style={styles.sectionLabel}>상세 설명</Text>
-              <Text style={styles.descText}>{item.description}</Text>
+              <Text style={styles.descText}>{itemPost.description}</Text>
             </View>
           )}
 
@@ -309,7 +309,7 @@ export default function LostItemDetail() {
       </ScrollView>
 
       <View style={[styles.bottomBar, { paddingBottom: insets.bottom + 8 }]}>
-        {item.type === "FOUND" && !isTheftConfirmed && (
+        {itemPost.type === "FOUND" && !isTheftConfirmed && (
           <TouchableOpacity
             style={styles.matchBtn}
             onPress={handleMatchRequest}

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -20,6 +20,9 @@ export const ITEMS_DETAIL_URL = BASE_URL + "/api/items/post/list";
 export const PROFILE_ME_URL = BASE_URL + "/api/profiles/me";
 export const USER_ACCOUNT_URL = BASE_URL + "/api/user/account";
 
+// Scan
+export const SCAN_OWNER = BASE_URL +  "/scan/owner";
+
 // Timetable
 export const TIMETABLES_URL = BASE_URL + "/api/timetables";
 export const COURSES_URL = BASE_URL + "/api/courses";

--- a/hooks/mutations/useChatMutations.ts
+++ b/hooks/mutations/useChatMutations.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { chatService } from "../../api/services/chat";
 import {
   ApiResponse,
+  CreateChatRoomByOwnerRequest,
   CreateChatRoomRequest,
   ListMessagesResult,
   MessageRecord,
@@ -18,6 +19,17 @@ export const useChatMutations = {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: CHAT_QUERY_KEYS.rooms });
       },
+    });
+  },
+
+  useCreateChatRoomByOwner: () => {
+    const queryClient = useQueryClient();
+    return useMutation({
+      mutationFn: (data: CreateChatRoomByOwnerRequest) => 
+        chatService.createChatRoomByOwner(data),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: CHAT_QUERY_KEYS.rooms });
+      }
     });
   },
 

--- a/hooks/queries/useItemQueries.ts
+++ b/hooks/queries/useItemQueries.ts
@@ -28,7 +28,7 @@ export const useItemQueries = {
     useItemDetail: (id: number | string) => {
         return useQuery({
             queryKey: ["itemDetail", id],
-            queryFn: () => itemService.getItemDetail(id),
+            queryFn: () => itemService.getItemPost(id),
             enabled: !!id,
         });
     },

--- a/utils/notifications/display.ts
+++ b/utils/notifications/display.ts
@@ -46,11 +46,6 @@ const createChatNotification = async (message: ZoopickRemoteMessage) => {
 
 const NOTIFICATION_DISPLAY_REGISTRY: Record<string, (message: ZoopickRemoteMessage) => void> = {
     CHAT_MESSAGE: createChatNotification,
-    ITEM_RETURNED: createSimpleNotification,
-    MATCH_FOUND: createSimpleNotification,
-    THEFT_SUSPECTED: createSimpleNotification,
-    LOCKER_READY: createSimpleNotification,
-    CCTV_FOUND: createSimpleNotification
 }
 
 export const displayNotification = async (message: ZoopickRemoteMessage) => {
@@ -61,5 +56,7 @@ export const displayNotification = async (message: ZoopickRemoteMessage) => {
     const displayer = NOTIFICATION_DISPLAY_REGISTRY[type];
     if (displayer) {
         displayer(message);
+    } else {
+        createSimpleNotification(message);
     }
 }

--- a/utils/notifications/routing.ts
+++ b/utils/notifications/routing.ts
@@ -26,6 +26,10 @@ const ROUTING_REGISTRY: Record<string, (data: NotificationData) => Href> = {
     CCTV_FOUND: (data) => ({
         pathname: ROUTES.CCTV_RESULT,
         params: { itemId: Number(data.item_id) }
+    }),
+    QR_SCANNED: (data) => ({
+        pathname: ROUTES.CHAT_ROOM,
+        params: { roomId: Number(data.room_id) }
     })
 }
 


### PR DESCRIPTION
### QR 스캔 및 채팅 연결 기능
- 사용자 QR 인식: 스캔 화면(scan.tsx)에서 /scan/owner/{id} 패턴의 QR 코드를 인식하여 해당 사용자와의 채팅방을 생성하거나 기존 채팅방으로 이동하는 기능을 추가했습니다.
- 채팅 생성 API 연동: useChatMutations.useCreateChatRoomByOwner를 추가하여 물건 주인과의 직접적인 채팅 연결이 가능하도록 했습니다.

### 사물함 보관 워크플로우 구현
- 거래 완료 모달 개선: 채팅방(chat-room.tsx)의 거래 완료 모달에 "📦 사물함에 물건을 넣을게요" 버튼을 추가했습니다.
- 스캔 화면 연동: 해당 버튼 클릭 시 itemId를 파라미터로 가지고 스캔 화면으로 이동하며, 스캔 성공 시 해당 아이템과 사물함을 연동하여 잠금을 해제합니다.

### 데이터 구조 및 타입 보완
- ItemPost 타입 수정: 채팅방 생성에 itemPostId를 사용하고 있어 itemId를 사용하도록 수정

Resolves: #44 