### PR TITLE
화면간 연결, 사물함 버튼

### DIFF
--- a/api/services/item.ts
+++ b/api/services/item.ts
@@ -8,6 +8,7 @@ import {
     ItemPost,
 } from "../types";
 import {
+    ITEM_BY_ITEM_ID,
     ITEMS_CREATE_URL,
     ITEMS_DETAIL_URL,
     ITEMS_LIST_URL,
@@ -26,6 +27,13 @@ export const itemService = {
     getItemPost: async (id: number | string) => {
         const response = await axiosInstance.get<ApiResponse<ItemPost>>(
             `${ITEMS_LIST_URL}/${id}`, // Swagger docs: /api/items/post/list/{id}
+        );
+        return response.data;
+    },
+
+    getItemPostByItemId: async (itemId: number | string) => {
+        const response = await axiosInstance.get<ApiResponse<ItemPost>>(
+            `${ITEM_BY_ITEM_ID}/${itemId}`, // Swagger docs: /api/items/post/by-item/{itemId}
         );
         return response.data;
     },

--- a/api/types.ts
+++ b/api/types.ts
@@ -202,6 +202,7 @@ export interface CreateItemRequest {
 
 export interface CreateItemResponse {
   item_post_id: number;
+  item_id: number;
   message: string;
   item_status: string;
 }

--- a/app.json
+++ b/app.json
@@ -22,7 +22,8 @@
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "package": "com.zoopick.android",
-      "googleServicesFile": "./google-services.json"
+      "googleServicesFile": "./google-services.json",
+      "permissions": ["POST_NOTIFICATIONS"]
     },
     "web": {
       "output": "static",

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -209,7 +209,10 @@ export default function QRScanScreen() {
     setModalType(null);
     setLockerId(null);
     if (itemIdParam) {
-      router.replace(`${ROUTES.LOST_ITEM_DETAIL}?id=${itemIdParam}` as any);
+      router.replace({
+          pathname: ROUTES.LOST_ITEM_DETAIL,
+          params: { itemId: itemIdParam }
+      });
     }
   };
 

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -248,6 +248,7 @@ export default function ChatRoomScreen() {
   const closeChatRoomMutation = useChatMutations.useCloseChatRoom(roomIdNum);
   const reopenChatRoomMutation = useChatMutations.useReopenChatRoom(roomIdNum);
 
+  const isOwnerQrScanned = roomData?.data.item_name === "";
   const chatRoom = roomData?.success ? roomData.data : null;
   const isOwner = profile?.nickname === chatRoom?.owner_nickname;
   const counterpartNickname = isOwner
@@ -344,14 +345,18 @@ export default function ChatRoomScreen() {
       setShowCloseModal(false);
       closeChatRoomMutation.mutate(reason, {
         onSuccess: () => {
-          if (reason === "RETURNED" && navigateToScan) {
+          const itemId = chatRoom?.item_id;
+          if (reason === "RETURNED" && navigateToScan && itemId) {
             Toast.show({
               type: "success",
               text1: "수령 완료! 사물함 QR을 스캔해서 물건을 꺼내주세요.",
               position: "bottom",
               visibilityTime: 3000,
             });
-            router.replace("/(tabs)/scan" as any);
+            router.replace({
+              pathname: ROUTES.SCAN,
+              params: { itemId: itemId }
+            });
           } else {
             Toast.show({
               type: "success",
@@ -597,12 +602,15 @@ export default function ChatRoomScreen() {
             <Text style={styles.modalDesc}>거래를 어떻게 종료할까요?</Text>
             {isOwner ? (
               <>
+              {isOwnerQrScanned ? (<></>) : (
                 <TouchableOpacity
                   style={styles.modalBtn}
                   onPress={() => handleClose("RETURNED", true)}
                 >
                   <Text style={styles.modalBtnText}>📦 사물함에서 물건을 꺼낼게요</Text>
                 </TouchableOpacity>
+              )
+              }
                 <TouchableOpacity
                   style={styles.modalBtn}
                   onPress={() => handleClose("RETURNED", false)}
@@ -612,12 +620,15 @@ export default function ChatRoomScreen() {
               </>
             ) : (
               <>
+              {isOwnerQrScanned ? (<></>) : (
                 <TouchableOpacity
                   style={styles.modalBtn}
                   onPress={() => handleOpenLocker()}
                 >
                   <Text style={styles.modalBtnText}>📦 사물함에 물건을 넣을게요</Text>
                 </TouchableOpacity>
+              )
+              }
                 <TouchableOpacity
                   style={styles.modalBtn}
                   onPress={() => handleClose("RETURNED")}

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -52,10 +52,13 @@ function formatDateTime(dateStr: string) {
 export default function LostItemDetail() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id: itemPostId, itemId } = useLocalSearchParams<{ id?: string, itemId?: string }>();
+  const id = itemPostId ? itemPostId : itemId;
+  const itemDetailQuery = itemPostId ? useItemQueries.useItemDetail : useItemQueries.useItemDetailByItemId;
+  
   const [showImageModal, setShowImageModal] = useState(false);
 
-  const { data: response, isLoading } = useItemQueries.useItemDetail(id!);
+  const { data: response, isLoading } = itemDetailQuery(id!);
   const createChatRoomMutation = useChatMutations.useCreateChatRoom();
   const { data: buildingsRes } = useMetadataQueries.useBuildings();
   const apiBuildings = buildingsRes?.data?.data ?? [];

--- a/app/lost-item-register.tsx
+++ b/app/lost-item-register.tsx
@@ -271,7 +271,7 @@ export default function LostItemRegister() {
                 },
                 {
                     onSuccess: (result) => {
-                        const itemId = result.data?.item_post_id;
+                        const itemId = result.data?.item_id;
                         if (deliveryChoice === "locker") {
                             if (!itemId) {
                                 Alert.alert(

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -13,6 +13,7 @@ export const CHECK_NICKNAME_URL = BASE_URL + "/api/auth/check-nickname";
 
 // Items
 export const ITEMS_LIST_URL = BASE_URL + "/api/items/post/list";
+export const ITEM_BY_ITEM_ID = BASE_URL + "/api/items/post/by-item";
 export const ITEMS_CREATE_URL = BASE_URL + "/api/items/post/create";
 export const ITEMS_DETAIL_URL = BASE_URL + "/api/items/post/list";
 

--- a/hooks/queries/useItemQueries.ts
+++ b/hooks/queries/useItemQueries.ts
@@ -32,4 +32,12 @@ export const useItemQueries = {
             enabled: !!id,
         });
     },
+
+    useItemDetailByItemId: (itemId: number | string) => {
+        return useQuery({
+            queryKey: ["itemDetail", itemId],
+            queryFn: () => itemService.getItemPostByItemId(itemId),
+            enabled: !!itemId,
+        })
+    }
 };

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -1,8 +1,8 @@
 import { authService } from "@/api/services/auth";
 import messaging from "@react-native-firebase/messaging";
 import { useEffect } from "react";
-import { PermissionsAndroid, Platform } from "react-native";
-import notifee from '@notifee/react-native';
+import { Platform } from "react-native";
+import notifee, { AuthorizationStatus } from '@notifee/react-native';
 import { TokenCallback } from "@/utils/notifications/types";
 import { displayNotification } from "@/utils/notifications/display";
 import { notificationEventHandler } from "@/utils/notifications/handlers";
@@ -43,13 +43,8 @@ const requestNotificationPermission = async () => {
             authStatus === messaging.AuthorizationStatus.PROVISIONAL
         );
     } else if (Platform.OS === "android") {
-        if (Platform.Version >= 33) {
-            const granted = await PermissionsAndroid.request(
-                PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
-            );
-            return granted === PermissionsAndroid.RESULTS.GRANTED;
-        }
-        return true;
+        const settings = await notifee.requestPermission();
+        return settings.authorizationStatus >= AuthorizationStatus.AUTHORIZED;
     }
     return false;
 };


### PR DESCRIPTION
## 개요
- **알림 권한 고도화**: Android API 30 이상 기기에서 알림 권한 상태를 정확히 감지하고 대응할 수 있도록 수정했습니다.
- **프로세스 정교화**: QR 스캔을 통한 주인 호출 시 불필요한 사물함 선택지를 제거하고, 아이템 ID 체계를 정립하여 데이터 로딩 오류를 해결했습니다.

## 주요 변경 사항

### 1. 알림 권한 처리 개선 (Android API 30+ 대응)
- `hooks/use-notifications.ts`: 기존 `PermissionsAndroid` 대신 `notifee.requestPermission()`을 사용하여 Android 11(API 30) 및 13+(API 33+)의 권한 상태를 통합 관리하도록 개선했습니다.
- `app.json`: Android Manifest에 `POST_NOTIFICATIONS` 권한을 명시적으로 추가하여 최신 Android 버전과의 호환성을 확보했습니다.

### 2. QR 스티커 주인 호출 로직 수정
- `app/chat-room.tsx`: QR 스티커 스캔으로 생성된 채팅방(아이템 이름이 비어 있는 경우)에서는 "사물함에 넣기/꺼내기" 옵션이 보이지 않도록 UI 분기 처리를 추가했습니다.
- #44, #47

### 3. 아이템 ID 기반 데이터 로딩 및 라우팅 수정
- **API 서비스**: `itemService.getItemPostByItemId` 및 관련 URL(`ITEM_BY_ITEM_ID`)을 추가하여 `item_id`만으로 게시글 정보를 가져올 수 있게 했습니다.
- **커스텀 훅**: `useItemDetailByItemId` 쿼리 훅을 추가하여 컴포넌트에서 쉽게 사용할 수 있도록 했습니다.
- **라우팅 수정**:
  - `LostItemRegister`: 등록 성공 후 `item_post_id` 대신 `item_id`를 전달하도록 수정했습니다.
  - `LostItemDetail`: `id` 뿐만 아니라 `itemId` 파라미터도 인식하여 적절한 API를 호출하도록 유연하게 변경했습니다.
  - `Scan`, `ChatRoom`: 페이지 이동 시 올바른 ID 파라미터를 넘겨주도록 수정했습니다.
- #48

### 4. 타입 및 기타
- `api/types.ts`: `CreateItemResponse`에 `item_id` 필드를 추가했습니다.

Resolves #47 