### PR TITLE
Feat: item_status 기반 채팅방 거래 종료 버튼 분기

### DIFF
--- a/api/types.ts
+++ b/api/types.ts
@@ -226,6 +226,7 @@ export interface ChatRoomRecord {
   finder_nickname: string;
   item_name: string;
   item_id: number;
+  item_status: ItemStatus | null;
 }
 
 export interface MessageRecord {

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -597,20 +597,21 @@ export default function ChatRoomScreen() {
             <Text style={styles.modalDesc}>거래를 어떻게 종료할까요?</Text>
             {isOwner ? (
               <>
-                {itemStatus === "IN_LOCKER" && (
+                {itemStatus === "IN_LOCKER" ? (
                   <TouchableOpacity
                     style={styles.modalBtn}
                     onPress={() => handleClose("RETURNED", true)}
                   >
                     <Text style={styles.modalBtnText}>📦 사물함에서 물건을 꺼낼게요</Text>
                   </TouchableOpacity>
+                ) : (
+                  <TouchableOpacity
+                    style={styles.modalBtn}
+                    onPress={() => handleClose("RETURNED", false)}
+                  >
+                    <Text style={styles.modalBtnText}>🤝 직접 물건을 받았어요</Text>
+                  </TouchableOpacity>
                 )}
-                <TouchableOpacity
-                  style={styles.modalBtn}
-                  onPress={() => handleClose("RETURNED", false)}
-                >
-                  <Text style={styles.modalBtnText}>🤝 직접 물건을 받았어요</Text>
-                </TouchableOpacity>
               </>
             ) : (
               <>

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -248,8 +248,8 @@ export default function ChatRoomScreen() {
   const closeChatRoomMutation = useChatMutations.useCloseChatRoom(roomIdNum);
   const reopenChatRoomMutation = useChatMutations.useReopenChatRoom(roomIdNum);
 
-  const itemStatus = chatRoom?.item_status ?? null;
   const chatRoom = roomData?.success ? roomData.data : null;
+  const itemStatus = chatRoom?.item_status ?? null;
   const isOwner = profile?.nickname === chatRoom?.owner_nickname;
   const counterpartNickname = isOwner
     ? chatRoom?.finder_nickname
@@ -597,15 +597,14 @@ export default function ChatRoomScreen() {
             <Text style={styles.modalDesc}>거래를 어떻게 종료할까요?</Text>
             {isOwner ? (
               <>
-              {isOwnerQrScanned ? (<></>) : (
-                <TouchableOpacity
-                  style={styles.modalBtn}
-                  onPress={() => handleClose("RETURNED", true)}
-                >
-                  <Text style={styles.modalBtnText}>📦 사물함에서 물건을 꺼낼게요</Text>
-                </TouchableOpacity>
-              )
-              }
+                {itemStatus === "IN_LOCKER" && (
+                  <TouchableOpacity
+                    style={styles.modalBtn}
+                    onPress={() => handleClose("RETURNED", true)}
+                  >
+                    <Text style={styles.modalBtnText}>📦 사물함에서 물건을 꺼낼게요</Text>
+                  </TouchableOpacity>
+                )}
                 <TouchableOpacity
                   style={styles.modalBtn}
                   onPress={() => handleClose("RETURNED", false)}
@@ -615,15 +614,14 @@ export default function ChatRoomScreen() {
               </>
             ) : (
               <>
-              {isOwnerQrScanned ? (<></>) : (
-                <TouchableOpacity
-                  style={styles.modalBtn}
-                  onPress={() => handleOpenLocker()}
-                >
-                  <Text style={styles.modalBtnText}>📦 사물함에 물건을 넣을게요</Text>
-                </TouchableOpacity>
-              )
-              }
+                {itemStatus === "REPORTED" && (
+                  <TouchableOpacity
+                    style={styles.modalBtn}
+                    onPress={handleOpenLocker}
+                  >
+                    <Text style={styles.modalBtnText}>📦 사물함에 물건을 넣을게요</Text>
+                  </TouchableOpacity>
+                )}
                 <TouchableOpacity
                   style={styles.modalBtn}
                   onPress={() => handleClose("RETURNED")}

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -327,18 +327,13 @@ export default function ChatRoomScreen() {
     sendMessageMutation,
   ]);
 
-  const handleOpenLocker = useCallback(
-    () => {
-      setShowCloseModal(false);
-      const itemId = chatRoom?.item_id;
-      if (itemId) {
-        router.replace({
-          pathname: ROUTES.SCAN,
-          params: { itemId: itemId }
-        });
-      }
-    }, []
-  );
+  const handleOpenLocker = useCallback(() => {
+    setShowCloseModal(false);
+    const itemId = chatRoom?.item_id;
+    if (itemId) {
+      router.replace({ pathname: ROUTES.SCAN, params: { itemId: itemId } });
+    }
+  }, [chatRoom]);
 
   const handleClose = useCallback(
     (reason: "RETURNED" | "ABANDONED", navigateToScan = false) => {
@@ -380,7 +375,7 @@ export default function ChatRoomScreen() {
         },
       });
     },
-    [closeChatRoomMutation],
+    [closeChatRoomMutation, chatRoom],
   );
 
   const handleReopen = useCallback(() => {

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -248,7 +248,7 @@ export default function ChatRoomScreen() {
   const closeChatRoomMutation = useChatMutations.useCloseChatRoom(roomIdNum);
   const reopenChatRoomMutation = useChatMutations.useReopenChatRoom(roomIdNum);
 
-  const isOwnerQrScanned = roomData?.data.item_name === "";
+  const itemStatus = chatRoom?.item_status ?? null;
   const chatRoom = roomData?.success ? roomData.data : null;
   const isOwner = profile?.nickname === chatRoom?.owner_nickname;
   const counterpartNickname = isOwner


### PR DESCRIPTION
 ## 개요
  
  백엔드에서 `ChatRoomRecord`에 `item_status` 필드가 추가됨에 따라,
  기존의 `item_name === ""` 프록시 방식을 제거하고 명시적인 상태값 기반으로 버튼 분기 로직을 교체합니다.

  ---

  ## 변경 내용

  ### api/types.ts
  - `ChatRoomRecord`에 `item_status: ItemStatus | null` 필드 추가

  ### app/chat-room.tsx
  - `isOwnerQrScanned` (`item_name === ""`) 제거 → `itemStatus = chatRoom?.item_status ?? null` 로 교체
  - `handleOpenLocker` stale closure 버그 수정: deps `[]` → `[chatRoom]`
  - `handleClose` stale closure 버그 수정: deps `[closeChatRoomMutation]` → `[closeChatRoomMutation, chatRoom]`
  - 거래 종료 모달 버튼 분기 교체

  ---

  ## 버튼 분기 규칙

  **owner**
  - `item_status === "IN_LOCKER"` → 📦 사물함에서 물건을 꺼낼게요 (사물함 QR 스캔 화면으로 이동)
  - 그 외 (null, REPORTED) → 🤝 직접 물건을 받았어요
  - 항상 노출: 거래를 포기할게요

  **finder**
  - `item_status === "REPORTED"` → 📦 사물함에 물건을 넣을게요 (추가 노출)
  - 항상 노출: ✅  물건을 찾아줬어요, 거래를 포기할게요


#51 