### PR TITLE
Feat: 내 글 채팅 버튼 숨김 및 UserProfile userId 필드 추가

### DIFF
--- a/api/types.ts
+++ b/api/types.ts
@@ -53,11 +53,12 @@ export interface DeviceTokenRequest {
 
 // User Profile Types
 export interface UserProfile {
+  userId: number;
   nickname: string;
   department: string;
   postCount: number;
   chatRoomCount: number;
-  unreadCount: number;
+  unreadNotificationCount: number;
 }
 
 export interface ScanOwnerResult {

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -100,7 +100,7 @@ export default function MyPageScreen() {
         </Text>
         <TouchableOpacity className="relative p-2" onPress={() => router.push(ROUTES.NOTIFICATION as any)}>
           <Bell size={24} color="#1F2937" />
-          {profile && profile.unreadCount > 0 && (
+          {profile && profile.unreadNotificationCount > 0 && (
             <View className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border-2 border-white" />
           )}
         </TouchableOpacity>
@@ -151,7 +151,7 @@ export default function MyPageScreen() {
           {[
             { label: "주은 물품", value: profile?.postCount ?? 0 },
             { label: "채팅방 수", value: profile?.chatRoomCount ?? 0 },
-            { label: "읽지 않은 알림", value: profile?.unreadCount ?? 0 },
+            { label: "읽지 않은 알림", value: profile?.unreadNotificationCount ?? 0 },
           ].map((stat, idx) => (
             <View
               key={stat.label}

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -11,6 +11,7 @@ import { BASE_URL } from "@/constants/url";
 import { useChatMutations } from "@/hooks/mutations/useChatMutations";
 import { useItemQueries } from "@/hooks/queries/useItemQueries";
 import { useMetadataQueries } from "@/hooks/queries/useMetadataQueries";
+import { useProfile } from "@/hooks/queries/useUserQueries";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import {
   AlertTriangle,
@@ -59,6 +60,7 @@ export default function LostItemDetail() {
   const [showImageModal, setShowImageModal] = useState(false);
 
   const { data: response, isLoading } = itemDetailQuery(id!);
+  const { data: profile } = useProfile();
   const createChatRoomMutation = useChatMutations.useCreateChatRoom();
   const { data: buildingsRes } = useMetadataQueries.useBuildings();
   const apiBuildings = buildingsRes?.data?.data ?? [];

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -73,40 +73,24 @@ export default function LostItemDetail() {
       : `${BASE_URL}${itemPost.image_url}`
     : null;
 
-  // 채팅 버튼 클릭 핸들러 (테스트용 ID 하드코딩)
   const handleChatPress = useCallback(() => {
     if (!itemPost) return;
-
-    console.log("reporter_id:", itemPost.reporter_id); // 추가!
-    console.log("=== 채팅 생성 테스트 시작 ===");
-    console.log("아이템 ID:", itemPost.item_id);
-
     createChatRoomMutation.mutate(
       {
         item_id: itemPost.item_id,
-        // 테스트를 위해 에뮬레이터 계정 ID를 1로 가정하고 하드코딩합니다.
-        //counterpart_id: 1,
-        // reporter_id 추가되면
         counterpart_id: itemPost.reporter_id ?? 0,
       },
       {
         onSuccess: (res) => {
-          console.log("채팅방 생성 성공:", JSON.stringify(res, null, 2)); // 이걸로 교체
           if (res.success && res.data.room_data) {
-            console.log("ROOM ID:", res.data.room_data.room_id); // 이것도 추가
-            // Expo Router 타입 시스템에 맞춘 안전한 이동 방식
             router.push({
               pathname: "/chat-room",
               params: { roomId: res.data.room_data.room_id },
             });
           }
         },
-        onError: (error) => {
-          console.error("채팅방 생성 실패:", error);
-          Alert.alert(
-            "알림",
-            "채팅방을 연결할 수 없습니다. 서버 로그를 확인하세요.",
-          );
+        onError: () => {
+          Alert.alert("알림", "채팅방을 열 수 없어요. 잠시 후 다시 시도해주세요.");
         },
       },
     );
@@ -126,22 +110,6 @@ export default function LostItemDetail() {
     } catch {
       Alert.alert("공유 실패");
     }
-  };
-
-  const handleMatchRequest = () => {
-    Alert.alert(
-      "매칭 요청",
-      "이 물건이 내 물건이 맞나요?\n요청 후 상대방과 채팅으로 확인할 수 있어요.",
-      [
-        { text: "취소", style: "cancel" },
-        {
-          text: "맞아요!",
-          onPress: () => {
-            Alert.alert("요청 완료", "매칭 요청을 보냈어요!");
-          },
-        },
-      ],
-    );
   };
 
   if (isLoading) {
@@ -183,6 +151,7 @@ export default function LostItemDetail() {
   const korCategory = CATEGORY_MAP[itemPost.category] ?? "기타";
   const IconComponent = CATEGORY_ICON_MAP[itemPost.category] ?? Package;
   const isTheftConfirmed = itemPost.status === "THEFT_CONFIRMED";
+  const isMyPost = !!profile && itemPost.reporter_id === profile.userId;
   const statusStyle = (isTheftConfirmed
     ? ITEM_STATUS_STYLE.THEFT_CONFIRMED
     : ITEM_STATUS_STYLE[itemPost.type]) ?? { bg: "#f3f4f6", text: "#888" };
@@ -314,32 +283,28 @@ export default function LostItemDetail() {
       </ScrollView>
 
       <View style={[styles.bottomBar, { paddingBottom: insets.bottom + 8 }]}>
-        {itemPost.type === "FOUND" && !isTheftConfirmed && (
+        {!isMyPost && (
           <TouchableOpacity
-            style={styles.matchBtn}
-            onPress={handleMatchRequest}
-            activeOpacity={0.85}
+            style={[
+              styles.chatBtn,
+              isTheftConfirmed && styles.chatBtnDisabled,
+            ]}
+            onPress={isTheftConfirmed ? undefined : handleChatPress}
+            activeOpacity={isTheftConfirmed ? 1 : 0.85}
+            disabled={createChatRoomMutation.isPending || isTheftConfirmed}
           >
-            <Text style={styles.matchBtnText}>이 물건 내 거예요</Text>
+            {createChatRoomMutation.isPending ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <>
+                <MessageCircle size={18} color="#fff" />
+                <Text style={styles.chatBtnText}>
+                  {isTheftConfirmed ? "도난 확정 처리됨" : "채팅으로 문의하기"}
+                </Text>
+              </>
+            )}
           </TouchableOpacity>
         )}
-        <TouchableOpacity
-          style={[styles.chatBtn, isTheftConfirmed && styles.chatBtnDisabled]}
-          onPress={isTheftConfirmed ? undefined : handleChatPress}
-          activeOpacity={isTheftConfirmed ? 1 : 0.85}
-          disabled={createChatRoomMutation.isPending || isTheftConfirmed}
-        >
-          {createChatRoomMutation.isPending ? (
-            <ActivityIndicator color="#fff" size="small" />
-          ) : (
-            <>
-              <MessageCircle size={18} color="#fff" />
-              <Text style={styles.chatBtnText}>
-                {isTheftConfirmed ? "도난 확정 처리됨" : "채팅으로 문의하기"}
-              </Text>
-            </>
-          )}
-        </TouchableOpacity>
         <TouchableOpacity
           style={styles.shareBtn}
           onPress={handleShare}


### PR DESCRIPTION
 ## 개요
  
  백엔드 `GET /api/profiles/me` 응답에 `userId` 필드가 추가됨에 따라,
  분실물 상세 화면에서 본인이 작성한 글인지 판별하여 채팅 버튼을 숨기는 로직을 구현합니다.
  미구현 상태였던 "이 물건 내 거예요" 버튼도 함께 제거합니다.

## 변경 내용

  ### api/types.ts
  - `UserProfile`에 `userId: number` 필드 추가
  - `unreadCount` → `unreadNotificationCount` 필드명 변경 (백엔드 응답과 일치)

  ### app/(tabs)/mypage.tsx
  - `unreadCount` 참조 2곳 → `unreadNotificationCount` 로 업데이트

  ### app/lost-item-detail.tsx
  - `useProfile()` 훅 추가
  - `isMyPost = itemPost.reporter_id === profile.userId` 판별 로직 추가
  - 내 글일 경우 채팅 버튼 숨김 처리 (`!isMyPost` 조건)
  - 미구현 상태의 "이 물건 내 거예요" 버튼 및 `handleMatchRequest` 함수 제거
  - 테스트용 `console.log` 전체 제거

  ## 동작 변경

  | 상황 | 기존 | 변경 후 |
  |---|---|---|
  | 남의 글 | 채팅 버튼 노출 | 채팅 버튼 노출 |
  | 내 글 | 채팅 버튼 노출 (자기 자신과 채팅 생성됨) | 채팅 버튼 숨김 |
  | FOUND 타입 글 | "이 물건 내 거예요" 버튼 노출 (미구현) | 제거 |