### PR TITLE
Feat: 알림 배지 기능 추가 및 읽음 처리 연동

### DIFF
--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -5,7 +5,8 @@ import { ROUTES } from "@/constants/url";
 import { useChatQueries } from "@/hooks/queries/useChatQueries";
 import { useProfile } from "@/hooks/queries/useUserQueries";
 import { useFocusEffect, useRouter } from "expo-router";
-import { Bell, MessageCircle, User } from "lucide-react-native";
+import NotificationBell from "@/components/NotificationBell";
+import { MessageCircle, User } from "lucide-react-native";
 import { useCallback, useEffect, useState } from "react";
 import {
   FlatList,
@@ -105,12 +106,7 @@ export default function ChatScreen() {
       <View style={styles.header}>
         <Text style={styles.headerTitle}>채팅</Text>
         <View style={styles.headerIcons}>
-          <TouchableOpacity
-            style={styles.iconBtn}
-            onPress={() => router.push(ROUTES.NOTIFICATION)}
-          >
-            <Bell size={20} color="#444" />
-          </TouchableOpacity>
+          <NotificationBell />
           <TouchableOpacity
             style={styles.iconBtn}
             onPress={() => router.push(ROUTES.MYPAGE as any)}

--- a/app/(tabs)/lost-item.tsx
+++ b/app/(tabs)/lost-item.tsx
@@ -12,8 +12,8 @@ import { BASE_URL, ROUTES } from "@/constants/url";
 import { useItemQueries } from "@/hooks/queries/useItemQueries";
 import { useMetadataQueries } from "@/hooks/queries/useMetadataQueries";
 import { useRouter } from "expo-router";
+import NotificationBell from "@/components/NotificationBell";
 import {
-  Bell,
   ChevronDown,
   MapPin,
   Package,
@@ -150,9 +150,7 @@ export default function LostItemBoard() {
         <View style={styles.header}>
           <Text style={styles.headerTitle}>분실물 게시판</Text>
           <View style={styles.headerIcons}>
-            <TouchableOpacity style={styles.iconBtn} onPress={() => router.push(ROUTES.NOTIFICATION)}>
-              <Bell size={20} color="#444" />
-            </TouchableOpacity>
+            <NotificationBell />
             <TouchableOpacity
               style={styles.iconBtn}
               onPress={() => router.push(ROUTES.MYPAGE)}

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -11,8 +11,8 @@ import { useItemQueries } from "@/hooks/queries/useItemQueries";
 import BottomSheet, { BottomSheetScrollView } from "@gorhom/bottom-sheet";
 import * as Location from "expo-location";
 import { useRouter } from "expo-router";
+import NotificationBell from "@/components/NotificationBell";
 import {
-  Bell,
   ChevronRight,
   Crosshair,
   Package,
@@ -271,9 +271,7 @@ export default function MapScreen() {
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <Text style={styles.headerTitle}>캠퍼스 지도</Text>
         <View style={styles.headerIcons}>
-          <TouchableOpacity style={styles.iconBtn} onPress={() => router.push(ROUTES.NOTIFICATION)}>
-            <Bell size={20} color="#444" />
-          </TouchableOpacity>
+          <NotificationBell />
           <TouchableOpacity
             style={styles.iconBtn}
             onPress={() => router.push(ROUTES.MYPAGE)}

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -8,9 +8,9 @@ import { CameraView, useCameraPermissions } from "expo-camera";
 import * as ImagePicker from "expo-image-picker";
 import { LinearGradient } from "expo-linear-gradient";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import NotificationBell from "@/components/NotificationBell";
 import {
   Archive,
-  Bell,
   Image as ImageIcon,
   MessageCircle,
   QrCode,
@@ -257,12 +257,7 @@ export default function QRScanScreen() {
       <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
         <Text style={styles.headerTitle}>QR 스캔</Text>
         <View style={styles.headerIcons}>
-          <TouchableOpacity
-            style={styles.iconBtn}
-            onPress={() => router.push(ROUTES.NOTIFICATION)}
-          >
-            <Bell size={20} color="#444" />
-          </TouchableOpacity>
+          <NotificationBell />
           <TouchableOpacity
             style={styles.iconBtn}
             onPress={() => router.push("/(tabs)/mypage" as any)}

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -1,6 +1,7 @@
 import client from "@/api/client";
 import { fonts } from "@/constants/typography";
 import { ROUTES } from "@/constants/url";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import {
   AlertTriangle,

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -89,6 +89,7 @@ function timeAgo(dateStr: string) {
 export default function NotificationsScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [notifications, setNotifications] = useState<NotificationRecord[]>([]);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -129,6 +130,7 @@ export default function NotificationsScreen() {
       setNotifications((prev) =>
         prev.map((n) => ({ ...n, read_at: new Date().toISOString() })),
       );
+      queryClient.invalidateQueries({ queryKey: ["userProfile"] });
     } catch (e) {
       console.error("알림 읽음 처리 실패", e);
     }
@@ -143,6 +145,7 @@ export default function NotificationsScreen() {
             n.id === item.id ? { ...n, read_at: new Date().toISOString() } : n,
           ),
         );
+        queryClient.invalidateQueries({ queryKey: ["userProfile"] });
       }
     } catch (e) {
       console.error("알림 읽음 처리 실패", e);

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,48 @@
+import { ROUTES } from "@/constants/url";
+import { useProfile } from "@/hooks/queries/useUserQueries";
+import { useRouter } from "expo-router";
+import { Bell } from "lucide-react-native";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
+
+export default function NotificationBell({
+  color = "#444",
+  size = 20,
+}: {
+  color?: string;
+  size?: number;
+}) {
+  const router = useRouter();
+  const { data: profile } = useProfile();
+  const hasUnread = (profile?.unreadNotificationCount ?? 0) > 0;
+
+  return (
+    <TouchableOpacity
+      style={styles.wrap}
+      onPress={() => router.push(ROUTES.NOTIFICATION)}
+    >
+      <Bell size={size} color={color} />
+      {hasUnread && <View style={styles.dot} />}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dot: {
+    position: "absolute",
+    top: 6,
+    right: 6,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: "#ef4444",
+    borderWidth: 1.5,
+    borderColor: "#fff",
+  },
+});


### PR DESCRIPTION
## 개요
  
  모든 탭 화면의 종 아이콘에 읽지 않은 알림이 있을 때 빨간 점 배지를 표시합니다.
  알림 읽음 처리 시 배지가 즉시 사라지도록 프로필 캐시와 연동합니다.

 ## 변경 내용

  ### components/NotificationBell.tsx (신규)
  - `useProfile()`의 `unreadNotificationCount > 0` 조건으로 빨간 점 표시
  - 알림 화면 이동 로직 내장
  - 기존 Bell 버튼을 대체하는 재사용 컴포넌트

  ### app/(tabs)/map.tsx, lost-item.tsx, chat.tsx, scan.tsx
  - 기존 Bell 아이콘 버튼 → `<NotificationBell />` 컴포넌트로 교체

  ### app/notifications.tsx
  - 개별 알림 읽음 처리 후 `queryClient.invalidateQueries(['userProfile'])` 추가
  - 전체 읽음 처리 후 동일하게 적용
  - 읽음 처리 즉시 종 아이콘 배지가 사라지도록 연동

  ---

  ## 동작

  | 상황 | 배지 |
  |---|---|
  | 읽지 않은 알림 1개 이상 | 빨간 점 표시 |
  | 모든 알림 읽음 / 알림 없음 | 배지 없음 |
  | 알림 화면에서 읽음 처리 | 즉시 배지 제거 |

#55


