### PR TITLE
Fix item post 백엔드 Item Post API 변경 반영 및 UI 개선

### DIFF
--- a/api/services/item.ts
+++ b/api/services/item.ts
@@ -5,13 +5,17 @@ import {
     CreateItemResponse,
     ItemFilter,
     ItemListResponse,
+    ItemOwnerInfoResult,
     ItemPost,
+    ItemType,
 } from "../types";
 import {
     ITEM_BY_ITEM_ID,
+    ITEM_OWNER_INFO_URL,
     ITEMS_CREATE_URL,
     ITEMS_DETAIL_URL,
     ITEMS_LIST_URL,
+    MY_ITEMS_URL,
 } from "@/constants/url";
 
 export const itemService = {
@@ -44,6 +48,20 @@ export const itemService = {
             data,
         );
         console.log(response.data);
+        return response.data;
+    },
+
+    getMyItems: async (type: ItemType) => {
+        const response = await axiosInstance.get<ApiResponse<ItemPost[]>>(
+            `${MY_ITEMS_URL}?type=${type}`,
+        );
+        return response.data;
+    },
+
+    getItemOwnerInfo: async (itemId: number) => {
+        const response = await axiosInstance.get<ApiResponse<ItemOwnerInfoResult>>(
+            `${ITEM_OWNER_INFO_URL}/${itemId}/owner-info`,
+        );
         return response.data;
     },
 };

--- a/api/types.ts
+++ b/api/types.ts
@@ -166,15 +166,19 @@ export interface ItemPost {
   id: number;
   title: string;
   description: string;
-  item_id: number;
   type: ItemType;
-  status: string;
+  status: ItemStatus;
   category: string;
+  name: string;
+  color: string;
+  nickname: string;
+  item_id: number;
+  reporter_id?: number;
   image_url: string;
   building_id: number;
   data_address: string;
   created_at: string;
-  reporter_id?: number;
+  reported_at: string;
 }
 
 export interface ItemListResponse {
@@ -205,7 +209,7 @@ export interface CreateItemResponse {
   item_post_id: number;
   item_id: number;
   message: string;
-  item_status: string;
+  item_status: ItemStatus;
 }
 
 // QR 스캔 시 물품 소유자 정보

--- a/app/(tabs)/lost-item.tsx
+++ b/app/(tabs)/lost-item.tsx
@@ -386,7 +386,7 @@ export default function LostItemBoard() {
                       </Text>
                     </View>
                     <Text style={styles.itemTime}>
-                      {timeAgo(item.created_at)}
+                      {(item.type === "FOUND" ? "발견 " : "분실 ") + timeAgo(item.reported_at)} · 게시 {timeAgo(item.created_at)}
                     </Text>
                   </View>
                   <View style={styles.itemRight}>

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -44,6 +44,7 @@ type ApiItem = {
   building_id: number;
   data_address?: string;
   created_at: string;
+  reported_at: string;
   image_url?: string;
 };
 
@@ -415,7 +416,7 @@ export default function MapScreen() {
                             `${buildingName} ${item.data_address ?? ""}`}
                         </Text>
                         <Text style={styles.itemMeta}>
-                          {timeAgo(item.created_at)}
+                          {timeAgo(item.reported_at)}
                         </Text>
                       </View>
                       <View style={styles.itemRight}>

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -12,9 +12,7 @@ import {
   Lock,
   LogOut,
   MessageCircle,
-  Package,
   Pencil,
-  QrCode,
   ShieldCheck,
   TrendingUp,
   User,
@@ -59,29 +57,6 @@ export default function MyPageScreen() {
       },
     ]);
   };
-
-  const quickMenus = [
-    {
-      label: "AI 매칭 내역",
-      icon: TrendingUp,
-      action: () => router.push(ROUTES.MATCHES),
-    },
-    {
-      label: "주은 물품 목록",
-      icon: Package,
-      action: () => router.push(ROUTES.LOST_ITEM_BOARD),
-    },
-    {
-      label: "채팅 목록",
-      icon: MessageCircle,
-      action: () => router.push(ROUTES.CHAT),
-    },
-    {
-      label: "스캔 내역",
-      icon: QrCode,
-      action: () => router.push(ROUTES.SCAN),
-    },
-  ];
 
   if (isLoading) {
     return (
@@ -224,29 +199,6 @@ export default function MyPageScreen() {
               </Text>
             </View>
           </TouchableOpacity>
-        </View>
-
-        {/* Quick Menus */}
-        <View className="mt-4 mx-4 bg-white rounded-3xl p-5 border border-gray-100 shadow-sm">
-          <Text className="text-sm font-pretendard-bold text-gray-800 mb-4">
-            빠른 메뉴
-          </Text>
-          <View className="flex-row flex-wrap justify-between">
-            {quickMenus.map((menu) => (
-              <TouchableOpacity
-                key={menu.label}
-                onPress={menu.action}
-                className="w-[48%] bg-gray-50 rounded-2xl p-4 flex-row items-center mb-3 border border-gray-100"
-              >
-                <View className="w-8 h-8 rounded-full bg-white items-center justify-center mr-3 shadow-sm">
-                  <menu.icon size={16} color="#4F6EF7" />
-                </View>
-                <Text className="text-xs font-pretendard-semibold text-gray-700">
-                  {menu.label}
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
         </View>
 
         {/* Settings Section */}

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -492,7 +492,7 @@ export default function ChatRoomScreen() {
             style={styles.completeBtn}
             onPress={() => setShowCloseModal(true)}
           >
-            <Text style={styles.completeBtnText}>거래 완료</Text>
+            <Text style={styles.completeBtnText}>{isOwner ? "반환 완료" : "양도 완료"}</Text>
           </TouchableOpacity>
         ) : (
           <TouchableOpacity style={styles.reopenBtn} onPress={handleReopen}>
@@ -524,7 +524,7 @@ export default function ChatRoomScreen() {
         <View style={styles.closedBanner}>
           <Text style={styles.closedText}>
             {chatRoom?.status === "RESOLVED_RETURNED"
-              ? "반환 완료된 거래입니다"
+              ? isOwner ? "반환 완료된 거래입니다" : "양도 완료된 거래입니다"
               : "종료된 거래입니다"}
           </Text>
         </View>

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -216,6 +216,7 @@ export default function LostItemDetail() {
           </View>
 
           <Text style={styles.title}>{itemPost.title ?? "제목 없음"}</Text>
+          <Text style={styles.nickname}>작성자: {itemPost.nickname}</Text>
 
           <View style={styles.locationCard}>
             <View style={styles.locationIconWrap}>
@@ -232,7 +233,7 @@ export default function LostItemDetail() {
                 {itemPost.type === "FOUND" ? "습득" : "분실"}
               </Text>
               <Text style={styles.locationTime}>
-                {formatDateTime(itemPost.created_at)}
+                {formatDateTime(itemPost.reported_at)}
               </Text>
             </View>
           </View>
@@ -392,8 +393,14 @@ const styles = StyleSheet.create({
     fontSize: 22,
     fontFamily: fonts.bold,
     color: "#111",
-    marginBottom: 16,
+    marginBottom: 6,
     lineHeight: 30,
+  },
+  nickname: {
+    fontSize: 13,
+    fontFamily: fonts.regular,
+    color: "#888",
+    marginBottom: 12,
   },
   locationCard: {
     flexDirection: "row",

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -16,6 +16,8 @@ export const ITEMS_LIST_URL = BASE_URL + "/api/items/post/list";
 export const ITEM_BY_ITEM_ID = BASE_URL + "/api/items/post/by-item";
 export const ITEMS_CREATE_URL = BASE_URL + "/api/items/post/create";
 export const ITEMS_DETAIL_URL = BASE_URL + "/api/items/post/list";
+export const MY_ITEMS_URL = BASE_URL + "/api/items/me";
+export const ITEM_OWNER_INFO_URL = BASE_URL + "/api/items";
 
 // User / Profiles
 export const PROFILE_ME_URL = BASE_URL + "/api/profiles/me";

--- a/hooks/queries/useItemQueries.ts
+++ b/hooks/queries/useItemQueries.ts
@@ -1,6 +1,6 @@
 import {useInfiniteQuery, useQuery} from "@tanstack/react-query";
 import {itemService} from "@/api/services/item";
-import {ItemFilter} from "@/api/types";
+import {ItemFilter, ItemType} from "@/api/types";
 
 export const useItemQueries = {
     useItems: (page = 0, size = 20, filter: ItemFilter = {}) => {
@@ -39,5 +39,20 @@ export const useItemQueries = {
             queryFn: () => itemService.getItemPostByItemId(itemId),
             enabled: !!itemId,
         })
-    }
+    },
+
+    useMyItems: (type: ItemType) => {
+        return useQuery({
+            queryKey: ["myItems", type],
+            queryFn: () => itemService.getMyItems(type),
+        });
+    },
+
+    useItemOwnerInfo: (itemId: number) => {
+        return useQuery({
+            queryKey: ["itemOwnerInfo", itemId],
+            queryFn: () => itemService.getItemOwnerInfo(itemId),
+            enabled: !!itemId,
+        });
+    },
 };


### PR DESCRIPTION
  백엔드 Item Post API 스펙 변경에 맞춰 타입·서비스·쿼리 훅을 업데이트하고, 실제 발견/분실 시각(reported_at) 및 신규 필드를 UI 전반에 반영합니다. 아울러 개발용 테스트 코드와 미사용 UI 컴포넌트를 정리합니다


API 레이어

  - api/types.ts
    - ItemPost에 name, color, nickname, reported_at 필드 추가
    - ItemPost.status 타입을 string → ItemStatus로 강화
    - CreateItemResponse.item_status 타입을 string → ItemStatus로 강화
  - constants/url.ts
    - MY_ITEMS_URL (/api/items/me), ITEM_OWNER_INFO_URL (/api/items) 상수 추가
  - api/services/item.ts
    - getMyItems(type) — 내 게시글 목록 조회 추가
    - getItemOwnerInfo(itemId) — 물품 소유자 정보 조회 추가
  - hooks/queries/useItemQueries.ts
    - useMyItems(type), useItemOwnerInfo(itemId) 쿼리 훅 추가

  UI — 시각 표시 개선 (created_at → reported_at)

  - app/(tabs)/lost-item.tsx — 카드 시간 표시를 "발견/분실 N시간 전 · 게시 N분 전" 형태로 변경
  - app/lost-item-detail.tsx — 위치 카드의 습득/분실 시각을 reported_at 기준으로 변경, 제목 아래 작성자: {nickname} 추가
  - app/(tabs)/map.tsx — 썸네일 카드 시간 표시를 reported_at 기준으로 변경

  UI — 채팅방 거래 상태 표시 개선

  - app/chat-room.tsx
    - 거래 완료 버튼: owner → "반환 완료", finder → "양도 완료"로 분기
    - 종료 배너: RESOLVED_RETURNED 상태에서 owner → "반환 완료된 거래입니다", finder → "양도 완료된 거래입니다"로 분기

  코드 정리

  - app/(tabs)/mypage.tsx — 빠른 메뉴(quickMenus) 섹션 및 미사용 import 삭제
  - app/(tabs)/scan.tsx — 개발용 모달 테스트 버튼 및 관련 핸들러·스타일 삭제

#62