### PR TITLE
Fix: QR 스캔 사물함 UX 개선 및 채팅 종료 플로우 정리

### DIFF
--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -136,7 +136,7 @@ export default function QRScanScreen() {
         try {
           await lockerService.unlock(
             parsed.lockerId,
-            parsed.itemId ?? undefined,
+            itemIdParam ? Number(itemIdParam) : (parsed.itemId ?? undefined),
           );
           setModalType("locker_success");
         } catch (e: any) {
@@ -196,6 +196,8 @@ export default function QRScanScreen() {
         await lockerService.lock(lockerId);
       } catch (e) {
         console.error("사물함 닫기 실패", e);
+        Alert.alert("오류", "사물함을 닫는 데 실패했어요. 다시 시도해주세요.");
+        return;
       }
     }
     setModalType(null);

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -45,7 +45,8 @@ type OwnerInfo = {
 export default function QRScanScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { itemId: itemIdParam } = useLocalSearchParams<{ itemId?: string }>();
+  const { itemId: itemIdParam, mode } = useLocalSearchParams<{ itemId?: string; mode?: string }>();
+  const isStoreMode = mode === "store";
   const [permission, requestPermission] = useCameraPermissions();
   const [isScanning, setIsScanning] = useState(false);
   const [modalType, setModalType] = useState<ModalType>(null);
@@ -199,7 +200,7 @@ export default function QRScanScreen() {
     }
     setModalType(null);
     setLockerId(null);
-    if (itemIdParam) {
+    if (isStoreMode && itemIdParam) {
       router.replace({
           pathname: ROUTES.LOST_ITEM_DETAIL,
           params: { itemId: itemIdParam }
@@ -264,7 +265,7 @@ export default function QRScanScreen() {
       {/* 바디 */}
       <View style={styles.body}>
         <Text style={styles.guideText}>
-          {itemIdParam
+          {isStoreMode
             ? "사물함 QR을 스캔하여 물건을 보관하세요"
             : "사물함 QR을 스캔하여 물건을 회수하세요"}
         </Text>
@@ -364,7 +365,7 @@ export default function QRScanScreen() {
             </View>
             <Text style={styles.modalTitle}>사물함이 열렸어요!</Text>
             <Text style={styles.modalDesc}>
-              {itemIdParam
+              {isStoreMode
                 ? `물건을 사물함에 넣은 후\n아래 버튼을 눌러 닫아주세요.`
                 : `물건을 꺼낸 후\n아래 버튼을 눌러 닫아주세요.`}
             </Text>
@@ -382,7 +383,7 @@ export default function QRScanScreen() {
               >
                 <Text style={styles.lockerCloseBtnText}>
                   {lockerReady
-                    ? itemIdParam
+                    ? isStoreMode
                       ? "넣었어요, 닫기"
                       : "꺼냈어요, 닫기"
                     : "사물함 열리는 중..."}

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -204,6 +204,9 @@ export default function QRScanScreen() {
           pathname: ROUTES.LOST_ITEM_DETAIL,
           params: { itemId: itemIdParam }
       });
+    } else {
+      setLockerReady(false);
+      router.navigate("/(tabs)/lost-item" as any);
     }
   };
 
@@ -261,7 +264,9 @@ export default function QRScanScreen() {
       {/* 바디 */}
       <View style={styles.body}>
         <Text style={styles.guideText}>
-          사물함 QR을 스캔하여 물건을 회수하세요
+          {itemIdParam
+            ? "사물함 QR을 스캔하여 물건을 보관하세요"
+            : "사물함 QR을 스캔하여 물건을 회수하세요"}
         </Text>
         <View style={styles.frameWrap}>
           <View style={styles.frame}>

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -362,6 +362,9 @@ export default function ChatRoomScreen() {
               position: "bottom",
               visibilityTime: 2500,
             });
+            if (reason === "RETURNED") {
+              router.replace("/(tabs)/lost-item" as any);
+            }
           }
         },
         onError: () => {

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -331,7 +331,7 @@ export default function ChatRoomScreen() {
     setShowCloseModal(false);
     const itemId = chatRoom?.item_id;
     if (itemId) {
-      router.replace({ pathname: ROUTES.SCAN, params: { itemId: itemId } });
+      router.replace({ pathname: ROUTES.SCAN, params: { itemId: itemId, mode: "store" } });
     }
   }, [chatRoom]);
 
@@ -350,7 +350,7 @@ export default function ChatRoomScreen() {
             });
             router.replace({
               pathname: ROUTES.SCAN,
-              params: { itemId: itemId }
+              params: { itemId: itemId, mode: "retrieve" }
             });
           } else {
             Toast.show({

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -606,8 +606,7 @@ export default function ChatRoomScreen() {
         />
         <View style={styles.modalWrap}>
           <View style={styles.modalCard}>
-            <Text style={styles.modalTitle}>거래 종료</Text>
-            <Text style={styles.modalDesc}>거래를 어떻게 종료할까요?</Text>
+            <Text style={styles.modalTitle}>마무리 방법 선택</Text>
             {isOwner ? (
               <>
                 {itemStatus === "IN_LOCKER" ? (
@@ -651,7 +650,7 @@ export default function ChatRoomScreen() {
               onPress={() => handleClose("ABANDONED")}
             >
               <Text style={[styles.modalBtnText, styles.modalBtnTextGray]}>
-                거래를 포기할게요
+                그냥 포기할게요
               </Text>
             </TouchableOpacity>
             <TouchableOpacity

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -358,8 +358,8 @@ export default function ChatRoomScreen() {
               type: "success",
               text1:
                 reason === "RETURNED"
-                  ? "거래가 완료되었어요"
-                  : "거래가 종료되었어요",
+                  ? "반환이 완료되었어요"
+                  : "연결이 종료되었어요",
               position: "bottom",
               visibilityTime: 2500,
             });
@@ -371,7 +371,7 @@ export default function ChatRoomScreen() {
         onError: () => {
           Toast.show({
             type: "error",
-            text1: "거래 종료 실패",
+            text1: "종료 처리 실패",
             text2: "다시 시도해주세요.",
             position: "bottom",
             visibilityTime: 2500,
@@ -498,7 +498,7 @@ export default function ChatRoomScreen() {
               if (!isOwner && itemStatus === "IN_LOCKER") {
                 Alert.alert(
                   "보관 중",
-                  "물건이 사물함에 보관 중입니다.\n분실자가 수령하면 거래가 완료돼요.",
+                  "물건이 사물함에 보관 중입니다.\n분실자가 물건을 찾아가면 마무리돼요.",
                 );
                 return;
               }
@@ -537,8 +537,8 @@ export default function ChatRoomScreen() {
         <View style={styles.closedBanner}>
           <Text style={styles.closedText}>
             {chatRoom?.status === "RESOLVED_RETURNED"
-              ? isOwner ? "반환 완료된 거래입니다" : "양도 완료된 거래입니다"
-              : "종료된 거래입니다"}
+              ? isOwner ? "반환이 완료된 채팅입니다" : "양도가 완료된 채팅입니다"
+              : "종료된 채팅입니다"}
           </Text>
         </View>
       )}
@@ -577,7 +577,7 @@ export default function ChatRoomScreen() {
           <TextInput
             style={[styles.input, isClosed && styles.inputDisabled]}
             placeholder={
-              isClosed ? "종료된 거래입니다" : "메시지를 입력하세요..."
+              isClosed ? "종료된 채팅입니다" : "메시지를 입력하세요..."
             }
             placeholderTextColor="#bbb"
             value={inputText}

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -25,6 +25,7 @@ import {
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   FlatList,
   KeyboardAvoidingView,
   Modal,
@@ -493,7 +494,16 @@ export default function ChatRoomScreen() {
         {!isClosed ? (
           <TouchableOpacity
             style={styles.completeBtn}
-            onPress={() => setShowCloseModal(true)}
+            onPress={() => {
+              if (!isOwner && itemStatus === "IN_LOCKER") {
+                Alert.alert(
+                  "보관 중",
+                  "물건이 사물함에 보관 중입니다.\n분실자가 수령하면 거래가 완료돼요.",
+                );
+                return;
+              }
+              setShowCloseModal(true);
+            }}
           >
             <Text style={styles.completeBtnText}>{isOwner ? "반환 완료" : "양도 완료"}</Text>
           </TouchableOpacity>
@@ -626,12 +636,14 @@ export default function ChatRoomScreen() {
                     <Text style={styles.modalBtnText}>📦 사물함에 물건을 넣을게요</Text>
                   </TouchableOpacity>
                 )}
-                <TouchableOpacity
-                  style={styles.modalBtn}
-                  onPress={() => handleClose("RETURNED")}
-                >
-                  <Text style={styles.modalBtnText}>✅ 물건을 찾아줬어요</Text>
-                </TouchableOpacity>
+                {itemStatus !== "IN_LOCKER" && (
+                  <TouchableOpacity
+                    style={styles.modalBtn}
+                    onPress={() => handleClose("RETURNED")}
+                  >
+                    <Text style={styles.modalBtnText}>✅ 물건을 찾아줬어요</Text>
+                  </TouchableOpacity>
+                )}
               </>
             )}
             <TouchableOpacity

--- a/app/lost-item-register.tsx
+++ b/app/lost-item-register.tsx
@@ -282,7 +282,7 @@ export default function LostItemRegister() {
                                 );
                                 return;
                             }
-                            router.push(`${ROUTES.SCAN}?itemId=${itemId}` as any);
+                            router.replace(`${ROUTES.SCAN}?itemId=${itemId}` as any);
                         } else {
                             if (itemId) router.replace(`${ROUTES.LOST_ITEM_DETAIL}?id=${itemPostId}`);
                             else router.back();

--- a/app/lost-item-register.tsx
+++ b/app/lost-item-register.tsx
@@ -282,7 +282,7 @@ export default function LostItemRegister() {
                                 );
                                 return;
                             }
-                            router.replace(`${ROUTES.SCAN}?itemId=${itemId}` as any);
+                            router.replace(`${ROUTES.SCAN}?itemId=${itemId}&mode=store` as any);
                         } else {
                             if (itemId) router.replace(`${ROUTES.LOST_ITEM_DETAIL}?id=${itemPostId}`);
                             else router.back();


### PR DESCRIPTION
 QR 스캔 화면이 소유자(보관)와 습득자(회수) 두 가지 진입 흐름을 공유하면서 발생한 UX 불일치와 논리적 오류를 수정합니다. 
채팅방 거래 종료 모달의 문구도 분실물 반환 맥락에 맞게 전면 정리합니다.

변경 사항

  app/(tabs)/scan.tsx

  mode 파라미터 도입으로 진입 흐름 명시적 분리
  - itemIdParam 유무만으로 보관/회수를 구분하던 방식을 mode=store / mode=retrieve 파라미터로 교체
  - 모든 텍스트 분기, 모달 문구, 닫기 후 네비게이션이 isStoreMode 기준으로 동작

  논리적 오류 수정
  - lockerService.lock() 실패 시 Alert 표시 후 화면 이동 차단 (기존: 사물함 열린 채로 이동)
  - JSON fallback 경로에서 itemIdParam 우선 사용, 없을 때만 parsed.itemId 폴백

  app/lost-item-register.tsx

  - 스캔 화면 진입 시 router.push → router.replace 변경
  - 보관 완료 후 뒤로가기 시 등록 페이지가 스택에 남던 문제 해결

  app/chat-room.tsx

  네비게이션 정리
  - handleOpenLocker → mode: "store", handleClose("RETURNED", true) → mode: "retrieve" 파라미터 추가
  - 직접 거래 완료(RETURNED, no scan) 후 게시판 탭으로 이동

  사물함 상태 논리 오류 수정
  - itemStatus === "IN_LOCKER" 상태에서 습득자의 "물건을 찾아줬어요" 버튼 숨김 (물건이 사물함 안에 있어 직접 전달 불가능한 상태)
  - 습득자가 IN_LOCKER 상태에서 "양도 완료" 버튼 누르면 모달 대신 안내 Alert 표시

  문구 개선 — "거래" 표현을 분실물 반환 맥락에 맞게 전면 수정

#61 
#62 
