### PR TITLE
 내 QR코드 발급 및 이미지 저장 / 보안·버그 수정, UI/UX 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 | 지도 기반 분실물 등록 | 카카오맵 위에서 위치를 지정하고 사진·카테고리와 함께 등록 |
 | AI 매칭 | 등록된 분실물과 습득물을 AI가 분석해 자동으로 매칭 제안 |
 | 실시간 채팅 | WebSocket 기반 1:1 채팅으로 당사자 간 직접 소통 |
+| 내 QR코드 발급 | 내 정보 페이지에서 개인 QR 코드를 조회하고 갤러리에 이미지 저장 |
 | QR 코드 스캔 | 물건에 부착된 QR 코드를 스캔해 소유자 정보 즉시 조회 |
 | IoT 사물함 제어 | QR 코드 스캔으로 교내 IoT 사물함 원격 개폐 |
 | CCTV 연동 | 교내 CCTV 영상에서 AI가 분실물을 탐지하고 결과를 제공 |
@@ -71,8 +72,11 @@ cd front
 npm install
 
 # 3. 환경변수 설정
-# 프로젝트 루트에 .env 파일 생성 후 아래 내용 입력
-echo "EXPO_PUBLIC_BASE_URL=http://52.63.7.132:8080" > .env
+# 프로젝트 루트에 .env 파일을 생성하고 아래 두 값을 입력하세요
+cat > .env << 'EOF'
+EXPO_PUBLIC_BASE_URL=http://52.63.7.132:8080
+EXPO_PUBLIC_KAKAO_API_KEY=your_kakao_api_key_here
+EOF
 
 # 4. Android 기기를 USB로 연결한 뒤 앱 빌드 및 실행
 npx expo run:android
@@ -95,8 +99,8 @@ npx expo run:android
 
 앱 실행 후 아래 권한을 허용해야 정상 동작합니다.
 
-- 카메라 — 분실물 사진 촬영
-- 사진/미디어 — 갤러리에서 사진 선택
+- 카메라 — 분실물 사진 촬영 및 QR 코드 스캔
+- 사진/미디어 — 갤러리에서 사진 선택 및 QR 코드 이미지 저장
 - 위치 — 캠퍼스 지도에서 현재 위치 표시
 
 </details>

--- a/api/services/user.ts
+++ b/api/services/user.ts
@@ -1,6 +1,6 @@
 import axiosInstance from "../client";
 import {UserProfile, UpdateProfileRequest, ScanOwnerResult, ApiResponse} from "../types";
-import {PROFILE_ME_URL, USER_ACCOUNT_URL} from "@/constants/url";
+import {PROFILE_ME_URL, PROFILE_ME_QR_URL, USER_ACCOUNT_URL} from "@/constants/url";
 
 export const userService = {
     getProfile: async () => {
@@ -19,6 +19,18 @@ export const userService = {
         // 필요시 구현 (ready ui에 있길래 넣어보긴함)
         const response = await axiosInstance.delete<void>(USER_ACCOUNT_URL);
         return response.data;
+    },
+
+    getMyQrCode: async (): Promise<string> => {
+        const response = await axiosInstance.get<ArrayBuffer>(PROFILE_ME_QR_URL, {
+            responseType: 'arraybuffer',
+        });
+        const bytes = new Uint8Array(response.data as ArrayBuffer);
+        let binary = '';
+        for (let i = 0; i < bytes.length; i += 8192) {
+            binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+        }
+        return `data:image/png;base64,${btoa(binary)}`;
     },
 
     scanQrCode: async (url: string) => {

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -74,7 +74,7 @@ export default function ChatScreen() {
           return res.success ? res.data : null;
         }),
       );
-      setChatRooms(rooms.filter(Boolean) as ChatRoomRecord[]);
+      setChatRooms((rooms.filter(Boolean) as ChatRoomRecord[]).sort((a, b) => b.room_id - a.room_id));
     } catch (e) {
       console.error("채팅방 목록 조회 실패", e);
       setChatRooms([]);

--- a/app/(tabs)/lost-item.tsx
+++ b/app/(tabs)/lost-item.tsx
@@ -4,6 +4,7 @@ import {
   CATEGORY_MAP,
   CATEGORY_TO_API,
   ITEM_STATUS_LABEL,
+  ITEM_STATUS_MAP,
   ITEM_STATUS_STYLE,
   ITEM_TYPE_MAP,
 } from "@/constants/categories";
@@ -15,6 +16,7 @@ import { useRouter } from "expo-router";
 import NotificationBell from "@/components/NotificationBell";
 import {
   ChevronDown,
+  Lock,
   MapPin,
   Package,
   Plus,
@@ -334,6 +336,7 @@ export default function LostItemBoard() {
             renderItem={({ item }) => {
               const korCategory = CATEGORY_MAP[item.category] ?? "기타";
               const isTheftConfirmed = item.status === "THEFT_CONFIRMED";
+              const isInLocker = item.status === "IN_LOCKER";
               const korStatus = isTheftConfirmed
                 ? ITEM_STATUS_LABEL.THEFT_CONFIRMED
                 : (ITEM_TYPE_MAP[item.type] ?? item.type);
@@ -391,14 +394,15 @@ export default function LostItemBoard() {
                   </View>
                   <View style={styles.itemRight}>
                     <View style={styles.statusBadge}>
-                      <View
-                        style={[
-                          styles.statusDot,
-                          { backgroundColor: statusStyle.dot },
-                        ]}
-                      />
+                      <View style={[styles.statusDot, { backgroundColor: statusStyle.dot }]} />
                       <Text style={styles.statusText}>{korStatus}</Text>
                     </View>
+                    {isInLocker && (
+                      <View style={styles.lockerBadge}>
+                        <Lock size={10} color="#f43f5e" />
+                        <Text style={styles.lockerBadgeText}>{ITEM_STATUS_MAP.IN_LOCKER}</Text>
+                      </View>
+                    )}
                   </View>
                 </TouchableOpacity>
               );
@@ -551,6 +555,8 @@ const styles = StyleSheet.create({
   },
   statusDot: { width: 6, height: 6, borderRadius: 3 },
   statusText: { fontSize: 11, fontFamily: fonts.bold, color: "#555" },
+  lockerBadge: { flexDirection: "row", alignItems: "center", gap: 3, backgroundColor: "#fff1f2", borderRadius: 8, paddingHorizontal: 8, paddingVertical: 4, marginTop: 4 },
+  lockerBadgeText: { fontSize: 10, fontFamily: fonts.bold, color: "#f43f5e" },
   emptyBox: { alignItems: "center", paddingVertical: 60 },
   emptyText: { fontSize: 14, color: "#aaa", fontFamily: fonts.regular },
   fab: {

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -2,6 +2,7 @@ import { BASE_BUILDINGS } from "@/constants/buildings";
 import {
   CATEGORY_ICON_MAP,
   CATEGORY_MAP,
+  ITEM_STATUS_MAP,
   ITEM_STATUS_STYLE,
   ITEM_TYPE_MAP,
 } from "@/constants/categories";
@@ -15,6 +16,7 @@ import NotificationBell from "@/components/NotificationBell";
 import {
   ChevronRight,
   Crosshair,
+  Lock,
   Package,
   Plus,
   Search,
@@ -373,10 +375,9 @@ export default function MapScreen() {
               ) : (
                 filteredItems.map((item) => {
                   const korCategory = CATEGORY_MAP[item.category] ?? "기타";
+                  const isInLocker = item.status === "IN_LOCKER";
                   const korStatus = ITEM_TYPE_MAP[item.type] ?? item.type;
-                  const statusStyle = ITEM_STATUS_STYLE[item.type] ?? {
-                    dot: "#aaa",
-                  };
+                  const statusStyle = ITEM_STATUS_STYLE[item.type] ?? { dot: "#aaa" };
                   const IconComponent =
                     CATEGORY_ICON_MAP[item.category] ?? Package;
                   const buildingName =
@@ -421,14 +422,15 @@ export default function MapScreen() {
                       </View>
                       <View style={styles.itemRight}>
                         <View style={styles.statusBadge}>
-                          <View
-                            style={[
-                              styles.statusDot,
-                              { backgroundColor: statusStyle.dot },
-                            ]}
-                          />
+                          <View style={[styles.statusDot, { backgroundColor: statusStyle.dot }]} />
                           <Text style={styles.statusText}>{korStatus}</Text>
                         </View>
+                        {isInLocker && (
+                          <View style={styles.lockerBadge}>
+                            <Lock size={10} color="#f43f5e" />
+                            <Text style={styles.lockerBadgeText}>{ITEM_STATUS_MAP.IN_LOCKER}</Text>
+                          </View>
+                        )}
                         <ChevronRight
                           size={14}
                           color="#ccc"
@@ -598,4 +600,6 @@ const styles = StyleSheet.create({
   },
   statusDot: { width: 5, height: 5, borderRadius: 3 },
   statusText: { fontSize: 10, fontFamily: fonts.bold, color: "#555" },
+  lockerBadge: { flexDirection: "row", alignItems: "center", gap: 3, backgroundColor: "#fff1f2", borderRadius: 8, paddingHorizontal: 6, paddingVertical: 3 },
+  lockerBadgeText: { fontSize: 10, fontFamily: fonts.bold, color: "#f43f5e" },
 });

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -35,7 +35,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 
-const KAKAO_API_KEY = "7488059674373cdf0eb9299fef1ec2ec";
+const KAKAO_API_KEY = process.env.EXPO_PUBLIC_KAKAO_API_KEY ?? "";
 
 type ApiItem = {
   id: number;

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -12,6 +12,7 @@ import {
   Lock,
   LogOut,
   MessageCircle,
+  QrCode,
   ShieldCheck,
   TrendingUp,
   User,
@@ -252,6 +253,21 @@ export default function MyPageScreen() {
           <Text className="text-sm font-pretendard-bold text-gray-800 px-5 pt-5 pb-3">
             계정
           </Text>
+
+          <TouchableOpacity
+            className="flex-row items-center justify-between px-5 py-4 border-t border-gray-50"
+            onPress={() => router.push(ROUTES.MY_QR as any)}
+          >
+            <View className="flex-row items-center">
+              <View className="w-8 h-8 rounded-xl bg-indigo-50 items-center justify-center mr-3">
+                <QrCode size={18} color="#6366F1" />
+              </View>
+              <Text className="text-sm font-pretendard-medium text-gray-700">
+                내 QR코드 발급
+              </Text>
+            </View>
+            <ChevronRight size={18} color="#D1D5DB" />
+          </TouchableOpacity>
 
           <TouchableOpacity className="flex-row items-center justify-between px-5 py-4 border-t border-gray-50">
             <View className="flex-row items-center">

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -9,7 +9,6 @@ import {
   Bell,
   Camera,
   ChevronRight,
-  Lock,
   LogOut,
   MessageCircle,
   QrCode,
@@ -264,18 +263,6 @@ export default function MyPageScreen() {
               </View>
               <Text className="text-sm font-pretendard-medium text-gray-700">
                 내 QR코드 발급
-              </Text>
-            </View>
-            <ChevronRight size={18} color="#D1D5DB" />
-          </TouchableOpacity>
-
-          <TouchableOpacity className="flex-row items-center justify-between px-5 py-4 border-t border-gray-50">
-            <View className="flex-row items-center">
-              <View className="w-8 h-8 rounded-xl bg-gray-50 items-center justify-center mr-3">
-                <Lock size={18} color="#6B7280" />
-              </View>
-              <Text className="text-sm font-pretendard-medium text-gray-700">
-                비밀번호 변경
               </Text>
             </View>
             <ChevronRight size={18} color="#D1D5DB" />

--- a/app/(tabs)/scan.tsx
+++ b/app/(tabs)/scan.tsx
@@ -45,7 +45,7 @@ type OwnerInfo = {
 export default function QRScanScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { itemId: itemIdParam, mode } = useLocalSearchParams<{ itemId?: string; mode?: string }>();
+  const { itemId: itemIdParam, mode, roomId: roomIdParam } = useLocalSearchParams<{ itemId?: string; mode?: string; roomId?: string }>();
   const isStoreMode = mode === "store";
   const [permission, requestPermission] = useCameraPermissions();
   const [isScanning, setIsScanning] = useState(false);
@@ -203,10 +203,11 @@ export default function QRScanScreen() {
     setModalType(null);
     setLockerId(null);
     if (isStoreMode && itemIdParam) {
-      router.replace({
-          pathname: ROUTES.LOST_ITEM_DETAIL,
-          params: { itemId: itemIdParam }
-      });
+      if (roomIdParam) {
+        router.replace({ pathname: ROUTES.CHAT_ROOM, params: { roomId: roomIdParam } });
+      } else {
+        router.replace({ pathname: ROUTES.LOST_ITEM_DETAIL, params: { itemId: itemIdParam } });
+      }
     } else {
       setLockerReady(false);
       router.navigate("/(tabs)/lost-item" as any);

--- a/app/cctv-items.tsx
+++ b/app/cctv-items.tsx
@@ -1,7 +1,8 @@
 import { BASE_URL, ROUTES } from "@/constants/url";
 import { useCctvQueries } from "@/hooks/queries/useCctvQueries";
 import { fonts } from "@/constants/typography";
-// import { mockCctvItems } from "@/mocks/cctv";
+import { CATEGORY_MAP } from "@/constants/categories";
+import { mockCctvItems } from "@/mocks/cctv";
 import { Camera, ChevronLeft, ChevronRight, Package } from "lucide-react-native";
 import {
     ActivityIndicator,
@@ -23,9 +24,8 @@ export default function CctvItemsScreen() {
     const [isRefreshing, setIsRefreshing] = useState(false);
 
     const { data, isLoading, refetch } = useCctvQueries.useMyItems();
-    // const USE_MOCK = true;
-    // const items = USE_MOCK ? mockCctvItems : (data?.data?.data?.matched_lost_items ?? []);
-    const items = data?.data?.data?.matched_lost_items ?? [];
+    const USE_MOCK = true;
+    const items = USE_MOCK ? mockCctvItems : (data?.data?.data?.matched_lost_items ?? []);
 
     const onRefresh = async () => {
         setIsRefreshing(true);
@@ -33,8 +33,7 @@ export default function CctvItemsScreen() {
         setIsRefreshing(false);
     };
 
-    // if (!USE_MOCK && isLoading) {
-    if (isLoading) {
+    if (!USE_MOCK && isLoading) {
         return (
             <View style={[styles.container, { alignItems: "center", justifyContent: "center" }]}>
                 <ActivityIndicator color="#ef4444" size="large" />
@@ -93,7 +92,7 @@ export default function CctvItemsScreen() {
                             <View style={styles.info}>
                                 <Text style={styles.title} numberOfLines={1}>{item.title}</Text>
                                 <View style={styles.categoryBadge}>
-                                    <Text style={styles.categoryText}>{item.category}</Text>
+                                    <Text style={styles.categoryText}>{CATEGORY_MAP[item.category] ?? item.category}</Text>
                                 </View>
                                 <Text style={styles.reportedAt}>{item.reported_at}</Text>
                             </View>

--- a/app/cctv-items.tsx
+++ b/app/cctv-items.tsx
@@ -2,7 +2,7 @@ import { BASE_URL, ROUTES } from "@/constants/url";
 import { useCctvQueries } from "@/hooks/queries/useCctvQueries";
 import { fonts } from "@/constants/typography";
 import { CATEGORY_MAP } from "@/constants/categories";
-import { mockCctvItems } from "@/mocks/cctv";
+// import { mockCctvItems } from "@/mocks/cctv";
 import { Camera, ChevronLeft, ChevronRight, Package } from "lucide-react-native";
 import {
     ActivityIndicator,
@@ -24,8 +24,9 @@ export default function CctvItemsScreen() {
     const [isRefreshing, setIsRefreshing] = useState(false);
 
     const { data, isLoading, refetch } = useCctvQueries.useMyItems();
-    const USE_MOCK = true;
-    const items = USE_MOCK ? mockCctvItems : (data?.data?.data?.matched_lost_items ?? []);
+    // const USE_MOCK = true;
+    // const items = USE_MOCK ? mockCctvItems : (data?.data?.data?.matched_lost_items ?? []);
+    const items = data?.data?.data?.matched_lost_items ?? [];
 
     const onRefresh = async () => {
         setIsRefreshing(true);
@@ -33,7 +34,8 @@ export default function CctvItemsScreen() {
         setIsRefreshing(false);
     };
 
-    if (!USE_MOCK && isLoading) {
+    // if (!USE_MOCK && isLoading) {
+    if (isLoading) {
         return (
             <View style={[styles.container, { alignItems: "center", justifyContent: "center" }]}>
                 <ActivityIndicator color="#ef4444" size="large" />

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -332,9 +332,9 @@ export default function ChatRoomScreen() {
     setShowCloseModal(false);
     const itemId = chatRoom?.item_id;
     if (itemId) {
-      router.replace({ pathname: ROUTES.SCAN, params: { itemId: itemId, mode: "store" } });
+      router.replace({ pathname: ROUTES.SCAN, params: { itemId: itemId, mode: "store", roomId: String(roomIdNum) } });
     }
-  }, [chatRoom]);
+  }, [chatRoom, roomIdNum]);
 
   const handleClose = useCallback(
     (reason: "RETURNED" | "ABANDONED", navigateToScan = false) => {

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -41,7 +41,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 
-const KAKAO_API_KEY = "7488059674373cdf0eb9299fef1ec2ec";
+const KAKAO_API_KEY = process.env.EXPO_PUBLIC_KAKAO_API_KEY ?? "";
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
 
 function formatDateTime(dateStr: string) {

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -3,6 +3,7 @@ import {
   CATEGORY_ICON_MAP,
   CATEGORY_MAP,
   ITEM_STATUS_LABEL,
+  ITEM_STATUS_MAP,
   ITEM_STATUS_STYLE,
   ITEM_TYPE_MAP,
 } from "@/constants/categories";
@@ -16,6 +17,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import {
   AlertTriangle,
   ChevronLeft,
+  Lock,
   MapPin,
   MessageCircle,
   Package,
@@ -151,6 +153,7 @@ export default function LostItemDetail() {
   const korCategory = CATEGORY_MAP[itemPost.category] ?? "기타";
   const IconComponent = CATEGORY_ICON_MAP[itemPost.category] ?? Package;
   const isTheftConfirmed = itemPost.status === "THEFT_CONFIRMED";
+  const isInLocker = itemPost.status === "IN_LOCKER";
   const isMyPost = !!profile && itemPost.reporter_id === profile.userId;
   const statusStyle = (isTheftConfirmed
     ? ITEM_STATUS_STYLE.THEFT_CONFIRMED
@@ -213,6 +216,12 @@ export default function LostItemDetail() {
                   : ITEM_TYPE_MAP[itemPost.type]}
               </Text>
             </View>
+            {isInLocker && (
+              <View style={[styles.statusBadge, { backgroundColor: "#fff1f2", flexDirection: "row", alignItems: "center", gap: 4 }]}>
+                <Lock size={11} color="#f43f5e" />
+                <Text style={[styles.statusBadgeText, { color: "#f43f5e" }]}>{ITEM_STATUS_MAP.IN_LOCKER}</Text>
+              </View>
+            )}
           </View>
 
           <Text style={styles.title}>{itemPost.title ?? "제목 없음"}</Text>
@@ -379,7 +388,7 @@ const styles = StyleSheet.create({
     paddingTop: 24,
     paddingBottom: 100,
   },
-  badgeRow: { flexDirection: "row", gap: 8, marginBottom: 12 },
+  badgeRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 12 },
   categoryBadge: {
     backgroundColor: "#f3f4f6",
     borderRadius: 20,

--- a/app/matches.tsx
+++ b/app/matches.tsx
@@ -209,7 +209,7 @@ export default function MatchesScreen() {
   ];
 
   const matches = USE_MOCK ? mockMatches : data?.success ? data.data : [];
-*/
+  */
 
   // 진행 중 매칭 (수락/거절 안 한 것)
   const pendingMatches = matches

--- a/app/my-qr.tsx
+++ b/app/my-qr.tsx
@@ -140,13 +140,7 @@ export default function MyQRScreen() {
       <View style={styles.tips}>
         <View style={styles.tipRow}>
           <ScanLine size={14} color="#888" />
-          <Text style={styles.tipText}>QR을 인쇄해서 물건에 부착해주세요</Text>
-        </View>
-        <View style={styles.tipRow}>
-          <Info size={14} color="#888" />
-          <Text style={styles.tipText}>
-            상대방이 스캔하기 쉽도록 화면을 밝게 해주세요
-          </Text>
+          <Text style={styles.tipText}>QR 이미지를 다운로드 후 인쇄해서 물건에 부착해주세요</Text>
         </View>
       </View>
     </View>

--- a/app/my-qr.tsx
+++ b/app/my-qr.tsx
@@ -1,16 +1,23 @@
 import { fonts } from "@/constants/typography";
-import { useProfile } from "@/hooks/queries/useUserQueries";
+import { PROFILE_ME_QR_URL } from "@/constants/url";
+import { useMyQrCode, useProfile } from "@/hooks/queries/useUserQueries";
+import { useAuthStore } from "@/store/authStore";
+import * as FileSystem from "expo-file-system/legacy";
+import * as MediaLibrary from "expo-media-library";
 import { useRouter } from "expo-router";
-import { ChevronLeft, Info, ScanLine, Sparkles } from "lucide-react-native";
+import { ChevronLeft, Download, Info, ScanLine, Sparkles } from "lucide-react-native";
+import { useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Dimensions,
+  Image,
+  Linking,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from "react-native";
-import QRCode from "react-native-qrcode-svg";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
@@ -19,25 +26,46 @@ const QR_SIZE = Math.min(SCREEN_WIDTH - 80, 260);
 export default function MyQRScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { data: profile, isLoading } = useProfile();
+  const { data: qrDataUri, isLoading: isQrLoading } = useMyQrCode();
+  const { data: profile, isLoading: isProfileLoading } = useProfile();
+  const [isSaving, setIsSaving] = useState(false);
 
-  if (isLoading) {
+  const handleDownload = async () => {
+    if (isSaving) return;
+    setIsSaving(true);
+    try {
+      const { status } = await MediaLibrary.requestPermissionsAsync();
+      if (status !== "granted") {
+        Alert.alert("갤러리 권한 필요", "설정에서 갤러리 권한을 허용해주세요.", [
+          { text: "취소", style: "cancel" },
+          { text: "설정 열기", onPress: () => Linking.openSettings() },
+        ]);
+        return;
+      }
+
+      const token = useAuthStore.getState().token;
+      const tempPath = FileSystem.cacheDirectory + "my-qr.png";
+      const result = await FileSystem.downloadAsync(
+        PROFILE_ME_QR_URL,
+        tempPath,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      await MediaLibrary.saveToLibraryAsync(result.uri);
+      Alert.alert("저장 완료", "QR 코드가 갤러리에 저장되었습니다.");
+    } catch {
+      Alert.alert("저장 실패", "이미지 저장 중 오류가 발생했습니다.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isQrLoading || isProfileLoading) {
     return (
-      <View
-        style={[
-          styles.container,
-          { alignItems: "center", justifyContent: "center" },
-        ]}
-      >
+      <View style={[styles.container, { alignItems: "center", justifyContent: "center" }]}>
         <ActivityIndicator color="#6366f1" size="large" />
       </View>
     );
   }
-
-  // QR 데이터: 닉네임 기반 (백엔드 명세에 따라 추후 수정 가능)
-  const qrValue = profile?.nickname
-    ? `zoopick://owner/${profile.nickname}`
-    : "zoopick://owner/unknown";
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
@@ -66,24 +94,47 @@ export default function MyQRScreen() {
       {/* QR 카드 */}
       <View style={styles.qrCard}>
         <View style={styles.qrWrap}>
-          <QRCode
-            value={qrValue}
-            size={QR_SIZE}
-            color="#111"
-            backgroundColor="#fff"
-          />
+          {qrDataUri ? (
+            <Image
+              source={{ uri: qrDataUri }}
+              style={{ width: QR_SIZE, height: QR_SIZE }}
+              resizeMode="contain"
+            />
+          ) : (
+            <View
+              style={{
+                width: QR_SIZE,
+                height: QR_SIZE,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Text style={styles.errorText}>QR 코드를 불러올 수 없습니다</Text>
+            </View>
+          )}
         </View>
 
         <View style={styles.profileBox}>
           <Text style={styles.profileLabel}>소유자</Text>
-          <Text style={styles.profileName}>
-            {profile?.nickname ?? "사용자"}
-          </Text>
+          <Text style={styles.profileName}>{profile?.nickname ?? "사용자"}</Text>
           {profile?.department ? (
             <Text style={styles.profileDept}>{profile.department}</Text>
           ) : null}
         </View>
       </View>
+
+      {/* 다운로드 버튼 */}
+      <TouchableOpacity
+        style={[styles.downloadBtn, isSaving && { opacity: 0.5 }]}
+        onPress={handleDownload}
+        disabled={isSaving}
+        activeOpacity={0.8}
+      >
+        <Download size={18} color="#fff" />
+        <Text style={styles.downloadBtnText}>
+          {isSaving ? "저장 중..." : "이미지 저장"}
+        </Text>
+      </TouchableOpacity>
 
       {/* 안내 사항 */}
       <View style={styles.tips}>
@@ -175,8 +226,25 @@ const styles = StyleSheet.create({
   profileLabel: { fontSize: 11, fontFamily: fonts.regular, color: "#aaa" },
   profileName: { fontSize: 18, fontFamily: fonts.bold, color: "#111" },
   profileDept: { fontSize: 12, fontFamily: fonts.regular, color: "#888" },
+  errorText: { fontSize: 13, fontFamily: fonts.regular, color: "#aaa" },
+  downloadBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    marginHorizontal: 20,
+    marginTop: 20,
+    paddingVertical: 14,
+    backgroundColor: "#6366f1",
+    borderRadius: 16,
+  },
+  downloadBtnText: {
+    fontSize: 15,
+    fontFamily: fonts.bold,
+    color: "#fff",
+  },
   tips: {
-    marginTop: 24,
+    marginTop: 20,
     marginHorizontal: 20,
     gap: 8,
   },

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -151,6 +151,7 @@ export default function NotificationsScreen() {
       console.error("알림 읽음 처리 실패", e);
     }
     const config = NOTIFICATION_CONFIG[item.type];
+    if (!config) return;
     router.push(config.route as any);
   };
 
@@ -214,6 +215,7 @@ export default function NotificationsScreen() {
         }
         renderItem={({ item }) => {
           const config = NOTIFICATION_CONFIG[item.type];
+          if (!config) return null;
           const IconComponent = config.icon;
           const isUnread = !item.read_at;
 

--- a/constants/categories.ts
+++ b/constants/categories.ts
@@ -45,6 +45,10 @@ export const ITEM_TYPE_MAP: Record<string, string> = {
   FOUND: "발견됨",
 };
 
+export const ITEM_STATUS_MAP: Record<string, string> = {
+  IN_LOCKER: "사물함 보관중",
+};
+
 export const ITEM_STATUS_STYLE: Record<
   string,
   { bg: string; text: string; dot: string }
@@ -52,6 +56,7 @@ export const ITEM_STATUS_STYLE: Record<
   LOST: { bg: "#fff7ed", text: "#f97316", dot: "#f97316" },
   FOUND: { bg: "#dcfce7", text: "#16a34a", dot: "#22c55e" },
   THEFT_CONFIRMED: { bg: "#fee2e2", text: "#dc2626", dot: "#ef4444" },
+  IN_LOCKER: { bg: "#fff1f2", text: "#f43f5e", dot: "#f43f5e" },
 };
 
 export const ITEM_STATUS_LABEL: Record<string, string> = {

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -21,6 +21,7 @@ export const ITEM_OWNER_INFO_URL = BASE_URL + "/api/items";
 
 // User / Profiles
 export const PROFILE_ME_URL = BASE_URL + "/api/profiles/me";
+export const PROFILE_ME_QR_URL = BASE_URL + "/api/profiles/me/qr";
 export const USER_ACCOUNT_URL = BASE_URL + "/api/user/account";
 
 // Scan

--- a/hooks/queries/useUserQueries.ts
+++ b/hooks/queries/useUserQueries.ts
@@ -9,3 +9,10 @@ export const useProfile = (options?: Partial<UseQueryOptions<UserProfile>>) => {
         ...options,
     });
 };
+
+export const useMyQrCode = () => {
+    return useQuery({
+        queryKey: ['myQrCode'],
+        queryFn: () => userService.getMyQrCode(),
+    });
+};

--- a/hooks/use-notifications.ts
+++ b/hooks/use-notifications.ts
@@ -50,8 +50,8 @@ const requestNotificationPermission = async () => {
 };
 
 export function useNotifications() {
-    messaging().setBackgroundMessageHandler(displayNotification);
     useEffect(() => {
+        messaging().setBackgroundMessageHandler(displayNotification);
         messaging().registerDeviceForRemoteMessages();
 
         requestNotificationPermission().then(granted => {

--- a/mocks/cctv.ts
+++ b/mocks/cctv.ts
@@ -4,7 +4,7 @@ export const mockCctvItems: CctvMatchedLostItem[] = [
     {
         lost_item_id: 1,
         title: "파란 우산",
-        category: "우산",
+        category: "UMBRELLA",
         match_count: 3,
         reported_at: "2026-05-14",
         image_url: "https://picsum.photos/seed/umbrella/200",
@@ -12,7 +12,7 @@ export const mockCctvItems: CctvMatchedLostItem[] = [
     {
         lost_item_id: 2,
         title: "에어팟 프로 케이스",
-        category: "전자기기",
+        category: "EARPHONES",
         match_count: 1,
         reported_at: "2026-05-15",
         image_url: "https://picsum.photos/seed/airpods/200",
@@ -20,7 +20,7 @@ export const mockCctvItems: CctvMatchedLostItem[] = [
     {
         lost_item_id: 3,
         title: "갈색 반지갑",
-        category: "지갑/가방",
+        category: "WALLET",
         match_count: 5,
         reported_at: "2026-05-16",
         image_url: "https://picsum.photos/seed/wallet/200",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.21",
         "expo-device": "~8.0.10",
+        "expo-file-system": "~19.0.23",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
@@ -7785,9 +7786,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "19.0.21",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
-      "integrity": "sha512-s3DlrDdiscBHtab/6W1osrjGL+C2bvoInPJD7sOwmxfJ5Woynv2oc+Fz1/xVXaE/V7HE/+xrHC/H45tu6lZzzg==",
+      "version": "19.0.23",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.23.tgz",
+      "integrity": "sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.21",
     "expo-device": "~8.0.10",
+    "expo-file-system": "~19.0.23",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",

--- a/utils/notifications/display.ts
+++ b/utils/notifications/display.ts
@@ -27,11 +27,11 @@ const createNotification = async (message: ZoopickRemoteMessage, actions: Androi
 }
 
 const createSimpleNotification = async (message: ZoopickRemoteMessage) => {
-    createNotification(message);
+    await createNotification(message);
 }
 
 const createChatNotification = async (message: ZoopickRemoteMessage) => {
-    createNotification(message, [
+    await createNotification(message, [
         {
             title: '읽음',
             pressAction: { id: 'read' }
@@ -47,11 +47,11 @@ const createChatNotification = async (message: ZoopickRemoteMessage) => {
 const createItemReportedNotification = async (message: ZoopickRemoteMessage) => {
     if (message.data && message.data.item_name)
         message.data.body += ` (${message.data.item_name})`;
-    
-    createNotification(message);
+
+    await createNotification(message);
 }
 
-const NOTIFICATION_DISPLAY_REGISTRY: Record<string, (message: ZoopickRemoteMessage) => void> = {
+const NOTIFICATION_DISPLAY_REGISTRY: Record<string, (message: ZoopickRemoteMessage) => Promise<void>> = {
     CHAT_MESSAGE: createChatNotification,
     ITEM_REPORTED: createItemReportedNotification
 }
@@ -63,8 +63,8 @@ export const displayNotification = async (message: ZoopickRemoteMessage) => {
     if (!type) return;
     const displayer = NOTIFICATION_DISPLAY_REGISTRY[type];
     if (displayer) {
-        displayer(message);
+        await displayer(message);
     } else {
-        createSimpleNotification(message);
+        await createSimpleNotification(message);
     }
 }


### PR DESCRIPTION

 Feat: 내 QR코드 발급 (app/(tabs)/mypage.tsx, app/my-qr.tsx)

 - 내 정보 페이지 계정 섹션에 내 QR코드 발급 버튼 추가
 - 기존 클라이언트 사이드 QR 생성 방식을 서버 API(GET /api/profiles/me/qr) 에서 PNG를 직접 받아오는 방식으로 교체
 - QR 화면에 이미지 저장 버튼 추가 — expo-media-library로 갤러리에 저장, 권한 미허용 시 설정 앱으로 유도

 Refactor: Kakao API 키 환경변수 처리 (app/(tabs)/map.tsx, app/lost-item-detail.tsx, .env)

 - 두 파일에 하드코딩되어 있던 Kakao Maps API 키를 EXPO_PUBLIC_KAKAO_API_KEY 환경변수로 이동
 - .env에 추가 (.gitignore 적용 중)

Fix: 알림 비동기 버그 수정 (utils/notifications/display.ts, hooks/use-notifications.ts)

 - createNotification 호출 4곳에 누락된 await 추가 — 알림 생성 중 에러가 조용히 무시되던 문제 수정
 - setBackgroundMessageHandler 호출을 useEffect 안으로 이동 — 렌더링마다 불필요하게 재등록되던 문제 수정

Remove: 비밀번호 변경 버튼 제거 (app/(tabs)/mypage.tsx)

 - 백엔드 미구현으로 인해 계정 섹션의 비밀번호 변경 버튼 제거

 Install: expo-file-system 패키지 추가

 - QR 이미지 다운로드 기능에 필요

 Docs: README 업데이트

 - 내 QR코드 발급 기능 추가
 - 환경변수 설정 섹션에 EXPO_PUBLIC_KAKAO_API_KEY 항목 추가
 - 앱 권한 안내에 QR 관련 용도 설명 추가

#62 
#57 
 