### PR TITLE
feat: 채팅 수 및 알림 라우팅 개선

### DIFF
--- a/api/types.ts
+++ b/api/types.ts
@@ -232,6 +232,9 @@ export interface ChatRoomRecord {
   item_name: string;
   item_id: number;
   item_status: ItemStatus | null;
+  unread_count?: number;
+  update_time?: string;
+  last_message?: string;
 }
 
 export interface MessageRecord {

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -105,7 +105,7 @@ export default function LoginPage() {
             >
               <Mail size={20} color="#fff" />
             </LinearGradient>
-            <Text style={styles.appName}>줍픽</Text>
+            <Text style={styles.appName}>줍줍</Text>
           </View>
 
           <View style={styles.inputWrapper}>

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,11 +1,11 @@
 import { chatService } from "@/api/services/chat";
 import { ChatRoomRecord } from "@/api/types";
+import NotificationBell from "@/components/NotificationBell";
 import { fonts } from "@/constants/typography";
 import { ROUTES } from "@/constants/url";
 import { useChatQueries } from "@/hooks/queries/useChatQueries";
 import { useProfile } from "@/hooks/queries/useUserQueries";
 import { useFocusEffect, useRouter } from "expo-router";
-import NotificationBell from "@/components/NotificationBell";
 import { MessageCircle, User } from "lucide-react-native";
 import { useCallback, useEffect, useState } from "react";
 import {
@@ -25,7 +25,11 @@ function timeAgo(dateStr: string) {
   if (min < 60) return `${min}분 전`;
   const hour = Math.floor(min / 60);
   if (hour < 24) return `${hour}시간 전`;
-  return "어제";
+  const day = Math.floor(hour / 24);
+  if (day < 2) return "어제";
+  if (day < 7) return `${day}일 전`;
+  const d = new Date(dateStr);
+  return `${d.getMonth() + 1}월 ${d.getDate()}일`;
 }
 
 const ChatRoomSkeleton = () => (
@@ -38,13 +42,7 @@ const ChatRoomSkeleton = () => (
           { width: "40%", height: 15, marginBottom: 6 },
         ]}
       />
-      <View
-        style={[
-          styles.skeletonLine,
-          { width: "60%", height: 12, marginBottom: 6 },
-        ]}
-      />
-      <View style={[styles.skeletonLine, { width: "30%", height: 12 }]} />
+      <View style={[styles.skeletonLine, { width: "60%", height: 12 }]} />
     </View>
   </View>
 );
@@ -74,7 +72,18 @@ export default function ChatScreen() {
           return res.success ? res.data : null;
         }),
       );
-      setChatRooms((rooms.filter(Boolean) as ChatRoomRecord[]).sort((a, b) => b.room_id - a.room_id));
+      setChatRooms(
+        (rooms.filter(Boolean) as ChatRoomRecord[]).sort((a, b) => {
+          // update_time 우선, 없으면 room_id 내림차순
+          if (a.update_time && b.update_time) {
+            return (
+              new Date(b.update_time).getTime() -
+              new Date(a.update_time).getTime()
+            );
+          }
+          return b.room_id - a.room_id;
+        }),
+      );
     } catch (e) {
       console.error("채팅방 목록 조회 실패", e);
       setChatRooms([]);
@@ -83,12 +92,10 @@ export default function ChatScreen() {
     }
   }, [roomListData]);
 
-  // 채팅방 ID 목록 변경 시 (새 채팅방 생성 등)
   useEffect(() => {
     loadChatRooms();
   }, [loadChatRooms]);
 
-  // 채팅 탭으로 돌아올 때 방 상태 갱신 (거래 완료 등 상태 변경 반영)
   useFocusEffect(
     useCallback(() => {
       loadChatRooms();
@@ -155,6 +162,16 @@ export default function ChatScreen() {
                 ? item.finder_nickname
                 : item.owner_nickname;
 
+            const isOpen = item.status === "OPEN";
+            const statusLabel =
+              item.status === "OPEN"
+                ? "진행 중"
+                : item.status === "RESOLVED_RETURNED"
+                  ? "반환 완료"
+                  : "종료";
+
+            const hasUnread = isOpen && (item.unread_count ?? 0) > 0;
+
             return (
               <TouchableOpacity
                 style={styles.chatCard}
@@ -169,23 +186,45 @@ export default function ChatScreen() {
                 <View style={styles.avatar}>
                   <User size={24} color="#aaa" />
                 </View>
+
                 <View style={styles.chatInfo}>
+                  {/* 상단: 닉네임 · 물건명 ........ 시간 */}
                   <View style={styles.chatTopRow}>
-                    <Text style={styles.chatNickname} numberOfLines={1}>
-                      {counterpartNickname}
-                    </Text>
+                    <View style={styles.chatTitleGroup}>
+                      <Text style={styles.chatNickname} numberOfLines={1}>
+                        {counterpartNickname}
+                      </Text>
+                      {item.item_name ? (
+                        <>
+                          <Text style={styles.chatDot}>·</Text>
+                          <Text style={styles.chatItemName} numberOfLines={1}>
+                            {item.item_name}
+                          </Text>
+                        </>
+                      ) : null}
+                    </View>
+                    {item.update_time ? (
+                      <Text style={styles.chatTime}>
+                        {timeAgo(item.update_time)}
+                      </Text>
+                    ) : null}
                   </View>
-                  <Text style={styles.chatItemDetail} numberOfLines={1}>
-                    {item.item_name}
-                  </Text>
+
+                  {/* 하단: 마지막 메시지 ........ (뱃지 또는 상태) */}
                   <View style={styles.chatBottomRow}>
-                    <Text style={styles.chatStatus} numberOfLines={1}>
-                      {item.status === "OPEN"
-                        ? "진행 중"
-                        : item.status === "RESOLVED_RETURNED"
-                          ? "반환 완료"
-                          : "종료"}
+                    <Text style={styles.chatLastMessage} numberOfLines={1}>
+                      {item.last_message ??
+                        (isOpen ? "대화를 시작해보세요" : statusLabel)}
                     </Text>
+                    {hasUnread ? (
+                      <View style={styles.unreadBadge}>
+                        <Text style={styles.unreadBadgeText}>
+                          {item.unread_count! > 99 ? "99+" : item.unread_count}
+                        </Text>
+                      </View>
+                    ) : !isOpen ? (
+                      <Text style={styles.chatStatus}>{statusLabel}</Text>
+                    ) : null}
                   </View>
                 </View>
               </TouchableOpacity>
@@ -236,28 +275,74 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     borderColor: "#6366f130",
   },
-  skeleton: {
-    backgroundColor: "#f0f0f0",
-    borderWidth: 0,
-  },
-  skeletonLine: {
-    backgroundColor: "#f0f0f0",
-    borderRadius: 6,
-  },
-  chatInfo: { flex: 1, gap: 3 },
+  skeleton: { backgroundColor: "#f0f0f0", borderWidth: 0 },
+  skeletonLine: { backgroundColor: "#f0f0f0", borderRadius: 6 },
+  chatInfo: { flex: 1, gap: 4 },
   chatTopRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
+    gap: 8,
   },
-  chatNickname: { fontSize: 15, fontFamily: fonts.bold, color: "#111" },
-  chatItemDetail: { fontSize: 12, fontFamily: fonts.regular, color: "#6366f1" },
+  chatTitleGroup: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 6,
+    flex: 1,
+    minWidth: 0,
+  },
+  chatNickname: {
+    fontSize: 15,
+    fontFamily: fonts.bold,
+    color: "#111",
+    flexShrink: 0,
+  },
+  chatDot: { fontSize: 12, color: "#ccc" },
+  chatItemName: {
+    fontSize: 12,
+    fontFamily: fonts.regular,
+    color: "#6366f1",
+    flex: 1,
+  },
+  chatTime: {
+    fontSize: 11,
+    fontFamily: fonts.regular,
+    color: "#aaa",
+    flexShrink: 0,
+  },
   chatBottomRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
+    gap: 8,
   },
-  chatStatus: { fontSize: 13, fontFamily: fonts.regular, color: "#aaa" },
+  chatLastMessage: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: fonts.regular,
+    color: "#666",
+  },
+  chatStatus: {
+    fontSize: 11,
+    fontFamily: fonts.regular,
+    color: "#888",
+    flexShrink: 0,
+  },
+  unreadBadge: {
+    minWidth: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: "#6366f1",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 6,
+    flexShrink: 0,
+  },
+  unreadBadgeText: {
+    fontSize: 11,
+    fontFamily: fonts.bold,
+    color: "#fff",
+  },
   emptyBox: { alignItems: "center", paddingVertical: 80, gap: 12 },
   emptyIconWrap: {
     width: 72,

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -145,52 +145,36 @@ export default function MyPageScreen() {
         <View className="flex-row gap-3 mx-4 mt-4">
           {/* AI 매칭 카드 */}
           <TouchableOpacity
-            className="flex-1 bg-white rounded-3xl p-4 border border-gray-100 shadow-sm overflow-hidden"
+            className="flex-1 bg-white rounded-3xl p-4 border border-gray-100 shadow-sm"
             onPress={() => router.push(ROUTES.MATCHES)}
             activeOpacity={0.85}
           >
             <View className="w-11 h-11 rounded-2xl bg-indigo-500 items-center justify-center mb-3">
               <TrendingUp size={22} color="#fff" />
             </View>
-            {/* 배경 원 장식 */}
-            <View
-              className="absolute top-3 right-3 w-16 h-16 rounded-full bg-indigo-100"
-              style={{ opacity: 0.4 }}
-            />
             <Text className="text-sm font-pretendard-bold text-gray-900 mb-0.5">
               AI 매칭
             </Text>
-            <Text className="text-xs font-pretendard-regular text-gray-400 mb-2">
+            <Text className="text-xs font-pretendard-regular text-gray-400">
               유사 분실물 자동 분석
             </Text>
-            <View className="flex-row items-center gap-1">
-              <View className="w-1.5 h-1.5 rounded-full bg-indigo-500" />
-            </View>
           </TouchableOpacity>
 
           {/* CCTV 분석 카드 */}
           <TouchableOpacity
-            className="flex-1 bg-white rounded-3xl p-4 border border-gray-100 shadow-sm overflow-hidden"
+            className="flex-1 bg-white rounded-3xl p-4 border border-gray-100 shadow-sm"
             onPress={() => router.push(ROUTES.CCTV_ITEMS)}
             activeOpacity={0.85}
           >
             <View className="w-11 h-11 rounded-2xl bg-red-400 items-center justify-center mb-3">
               <Camera size={22} color="#fff" />
             </View>
-            {/* 배경 원 장식 */}
-            <View
-              className="absolute top-3 right-3 w-16 h-16 rounded-full bg-red-100"
-              style={{ opacity: 0.4 }}
-            />
             <Text className="text-sm font-pretendard-bold text-gray-900 mb-0.5">
               CCTV 분석
             </Text>
-            <Text className="text-xs font-pretendard-regular text-gray-400 mb-2">
+            <Text className="text-xs font-pretendard-regular text-gray-400">
               도난 영상 분석 현황
             </Text>
-            <View className="flex-row items-center gap-1">
-              <View className="w-1.5 h-1.5 rounded-full bg-gray-300" />
-            </View>
           </TouchableOpacity>
         </View>
 

--- a/app/chat-room.tsx
+++ b/app/chat-room.tsx
@@ -332,7 +332,10 @@ export default function ChatRoomScreen() {
     setShowCloseModal(false);
     const itemId = chatRoom?.item_id;
     if (itemId) {
-      router.replace({ pathname: ROUTES.SCAN, params: { itemId: itemId, mode: "store", roomId: String(roomIdNum) } });
+      router.replace({
+        pathname: ROUTES.SCAN,
+        params: { itemId: itemId, mode: "store", roomId: String(roomIdNum) },
+      });
     }
   }, [chatRoom, roomIdNum]);
 
@@ -351,7 +354,7 @@ export default function ChatRoomScreen() {
             });
             router.replace({
               pathname: ROUTES.SCAN,
-              params: { itemId: itemId, mode: "retrieve" }
+              params: { itemId: itemId, mode: "retrieve" },
             });
           } else {
             Toast.show({
@@ -505,7 +508,9 @@ export default function ChatRoomScreen() {
               setShowCloseModal(true);
             }}
           >
-            <Text style={styles.completeBtnText}>{isOwner ? "반환 완료" : "양도 완료"}</Text>
+            <Text style={styles.completeBtnText}>
+              {isOwner ? "반환 완료" : "양도 완료"}
+            </Text>
           </TouchableOpacity>
         ) : (
           <TouchableOpacity style={styles.reopenBtn} onPress={handleReopen}>
@@ -522,7 +527,16 @@ export default function ChatRoomScreen() {
 
       {/* 분실물 배너 */}
       {chatRoom && (
-        <View style={styles.itemBanner}>
+        <TouchableOpacity
+          style={styles.itemBanner}
+          onPress={() =>
+            router.push({
+              pathname: ROUTES.LOST_ITEM_DETAIL,
+              params: { itemId: String(chatRoom.item_id) },
+            })
+          }
+          activeOpacity={0.7}
+        >
           <View style={styles.itemBannerIcon}>
             <Package size={16} color="#6366f1" />
           </View>
@@ -530,14 +544,16 @@ export default function ChatRoomScreen() {
             {chatRoom.item_name}
           </Text>
           <ChevronRight size={14} color="#aaa" />
-        </View>
+        </TouchableOpacity>
       )}
 
       {isClosed && (
         <View style={styles.closedBanner}>
           <Text style={styles.closedText}>
             {chatRoom?.status === "RESOLVED_RETURNED"
-              ? isOwner ? "반환이 완료된 채팅입니다" : "양도가 완료된 채팅입니다"
+              ? isOwner
+                ? "반환이 완료된 채팅입니다"
+                : "양도가 완료된 채팅입니다"
               : "종료된 채팅입니다"}
           </Text>
         </View>
@@ -614,14 +630,18 @@ export default function ChatRoomScreen() {
                     style={styles.modalBtn}
                     onPress={() => handleClose("RETURNED", true)}
                   >
-                    <Text style={styles.modalBtnText}>📦 사물함에서 물건을 꺼낼게요</Text>
+                    <Text style={styles.modalBtnText}>
+                      📦 사물함에서 물건을 꺼낼게요
+                    </Text>
                   </TouchableOpacity>
                 ) : (
                   <TouchableOpacity
                     style={styles.modalBtn}
                     onPress={() => handleClose("RETURNED", false)}
                   >
-                    <Text style={styles.modalBtnText}>🤝 직접 물건을 받았어요</Text>
+                    <Text style={styles.modalBtnText}>
+                      🤝 직접 물건을 받았어요
+                    </Text>
                   </TouchableOpacity>
                 )}
               </>
@@ -632,7 +652,9 @@ export default function ChatRoomScreen() {
                     style={styles.modalBtn}
                     onPress={handleOpenLocker}
                   >
-                    <Text style={styles.modalBtnText}>📦 사물함에 물건을 넣을게요</Text>
+                    <Text style={styles.modalBtnText}>
+                      📦 사물함에 물건을 넣을게요
+                    </Text>
                   </TouchableOpacity>
                 )}
                 {itemStatus !== "IN_LOCKER" && (
@@ -640,7 +662,9 @@ export default function ChatRoomScreen() {
                     style={styles.modalBtn}
                     onPress={() => handleClose("RETURNED")}
                   >
-                    <Text style={styles.modalBtnText}>✅ 물건을 찾아줬어요</Text>
+                    <Text style={styles.modalBtnText}>
+                      ✅ 물건을 찾아줬어요
+                    </Text>
                   </TouchableOpacity>
                 )}
               </>

--- a/app/lost-item-detail.tsx
+++ b/app/lost-item-detail.tsx
@@ -55,10 +55,15 @@ function formatDateTime(dateStr: string) {
 export default function LostItemDetail() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { id: itemPostId, itemId } = useLocalSearchParams<{ id?: string, itemId?: string }>();
+  const { id: itemPostId, itemId } = useLocalSearchParams<{
+    id?: string;
+    itemId?: string;
+  }>();
   const id = itemPostId ? itemPostId : itemId;
-  const itemDetailQuery = itemPostId ? useItemQueries.useItemDetail : useItemQueries.useItemDetailByItemId;
-  
+  const itemDetailQuery = itemPostId
+    ? useItemQueries.useItemDetail
+    : useItemQueries.useItemDetailByItemId;
+
   const [showImageModal, setShowImageModal] = useState(false);
 
   const { data: response, isLoading } = itemDetailQuery(id!);
@@ -92,7 +97,10 @@ export default function LostItemDetail() {
           }
         },
         onError: () => {
-          Alert.alert("알림", "채팅방을 열 수 없어요. 잠시 후 다시 시도해주세요.");
+          Alert.alert(
+            "알림",
+            "채팅방을 열 수 없어요. 잠시 후 다시 시도해주세요.",
+          );
         },
       },
     );
@@ -107,7 +115,7 @@ export default function LostItemDetail() {
       : sharedBuildingName;
     try {
       await Share.share({
-        message: `[줍픽] ${itemPost.title ?? "분실물"} - ${locationText}`,
+        message: `[줍줍] ${itemPost.title ?? "분실물"} - ${locationText}`,
       });
     } catch {
       Alert.alert("공유 실패");
@@ -217,9 +225,21 @@ export default function LostItemDetail() {
               </Text>
             </View>
             {isInLocker && (
-              <View style={[styles.statusBadge, { backgroundColor: "#fff1f2", flexDirection: "row", alignItems: "center", gap: 4 }]}>
+              <View
+                style={[
+                  styles.statusBadge,
+                  {
+                    backgroundColor: "#fff1f2",
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 4,
+                  },
+                ]}
+              >
                 <Lock size={11} color="#f43f5e" />
-                <Text style={[styles.statusBadgeText, { color: "#f43f5e" }]}>{ITEM_STATUS_MAP.IN_LOCKER}</Text>
+                <Text style={[styles.statusBadgeText, { color: "#f43f5e" }]}>
+                  {ITEM_STATUS_MAP.IN_LOCKER}
+                </Text>
               </View>
             )}
           </View>
@@ -251,7 +271,8 @@ export default function LostItemDetail() {
             <View style={styles.theftBanner}>
               <AlertTriangle size={16} color="#dc2626" />
               <Text style={styles.theftBannerText}>
-                도난이 확정된 물건입니다. 경찰에 신고되었거나 수사 중일 수 있어요.
+                도난이 확정된 물건입니다. 경찰에 신고되었거나 수사 중일 수
+                있어요.
               </Text>
             </View>
           )}
@@ -295,10 +316,7 @@ export default function LostItemDetail() {
       <View style={[styles.bottomBar, { paddingBottom: insets.bottom + 8 }]}>
         {!isMyPost && (
           <TouchableOpacity
-            style={[
-              styles.chatBtn,
-              isTheftConfirmed && styles.chatBtnDisabled,
-            ]}
+            style={[styles.chatBtn, isTheftConfirmed && styles.chatBtnDisabled]}
             onPress={isTheftConfirmed ? undefined : handleChatPress}
             activeOpacity={isTheftConfirmed ? 1 : 0.85}
             disabled={createChatRoomMutation.isPending || isTheftConfirmed}
@@ -388,7 +406,12 @@ const styles = StyleSheet.create({
     paddingTop: 24,
     paddingBottom: 100,
   },
-  badgeRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 12 },
+  badgeRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginBottom: 12,
+  },
   categoryBadge: {
     backgroundColor: "#f3f4f6",
     borderRadius: 20,

--- a/app/matches.tsx
+++ b/app/matches.tsx
@@ -15,6 +15,7 @@ import {
   MessageCircle,
   QrCode,
   Sparkles,
+  User,
   XCircle,
 } from "lucide-react-native";
 import { useState } from "react";
@@ -75,9 +76,7 @@ function AcceptedSheet({
             <View style={sheetStyles.infoBox}>
               <View style={sheetStyles.finderRow}>
                 <View style={sheetStyles.finderAvatar}>
-                  <Text style={sheetStyles.finderAvatarText}>
-                    {match.found_nickname?.charAt(0) ?? "?"}
-                  </Text>
+                  <User size={22} color="#aaa" />
                 </View>
                 <View>
                   <Text style={sheetStyles.finderName}>
@@ -163,7 +162,6 @@ export default function MatchesScreen() {
   const [modalType, setModalType] = useState<"reject" | null>(null);
   const [acceptedIds, setAcceptedIds] = useState<number[]>([]);
   const [rejectedIds, setRejectedIds] = useState<number[]>([]);
-  // 수락 후 바텀시트
   const [acceptedSheet, setAcceptedSheet] = useState<{
     match: ItemMatchResultResponse;
     matchType: "CHAT" | "LOCKER";
@@ -176,49 +174,12 @@ export default function MatchesScreen() {
 
   const matches = data?.success ? data.data : [];
 
-  /*
-  // ⚠️ 임시 테스트용 mock (검증 후 반드시 삭제!)
-  const USE_MOCK = true;
-  const mockMatches: ItemMatchResultResponse[] = [
-    {
-      match_id: 999,
-      status: "CANDIDATE",
-      score: 0.92,
-      found_item_id: 52,
-      found_post_id: 45,
-      found_post_title: "파란 물병 주웠어요",
-      found_image_url: "",
-      location_name: "제1공학관 Y5441",
-      found_nickname: "테스트유저",
-      found_department: "컴퓨터공학과",
-      counterpart_id: 7,
-    },
-    {
-      match_id: 998,
-      status: "CANDIDATE",
-      score: 0.78,
-      found_item_id: 51,
-      found_post_id: 44,
-      found_post_title: "검정 텀블러 발견",
-      found_image_url: "",
-      location_name: "제2공학관",
-      found_nickname: "신성민",
-      found_department: "산업경영공학과",
-      counterpart_id: 8,
-    },
-  ];
-
-  const matches = USE_MOCK ? mockMatches : data?.success ? data.data : [];
-  */
-
-  // 진행 중 매칭 (수락/거절 안 한 것)
   const pendingMatches = matches
     .filter((m) => m.status === "CANDIDATE" || m.status === "NOTIFIED")
-    .filter((m) => !rejectedIds.includes(m.match_id)) // 거절된 것 제외
-    .filter((m) => !acceptedIds.includes(m.match_id)) // 수락된 것 제외 (완료 섹션으로 이동)
+    .filter((m) => !rejectedIds.includes(m.match_id))
+    .filter((m) => !acceptedIds.includes(m.match_id))
     .sort((a, b) => b.score - a.score);
 
-  // 완료된 매칭 (수락된 것들)
   const completedMatches = matches.filter((m) =>
     acceptedIds.includes(m.match_id),
   );
@@ -253,10 +214,9 @@ export default function MatchesScreen() {
           return;
         }
 
-        const { match_type, counterpart_id } = res.data;
+        const { match_type } = res.data;
         setAcceptedIds((prev) => [...prev, match.match_id]);
 
-        // 수락 후 바텀시트 표시
         setAcceptedSheet({ match, matchType: match_type });
       },
       onError: () => {
@@ -275,7 +235,6 @@ export default function MatchesScreen() {
     if (!selectedMatchId) return;
     const targetId = selectedMatchId;
     closeModal();
-    // 거절 즉시 카드 제거
     setRejectedIds((prev) => [...prev, targetId]);
 
     rejectMutation.mutate(targetId, {
@@ -288,7 +247,6 @@ export default function MatchesScreen() {
         });
       },
       onError: () => {
-        // API 실패 시 복원
         setRejectedIds((prev) => prev.filter((id) => id !== targetId));
         Toast.show({
           type: "error",
@@ -300,7 +258,6 @@ export default function MatchesScreen() {
     });
   };
 
-  // 바텀시트 - 채팅하기
   const handleGoChat = () => {
     if (!acceptedSheet) return;
     const { match } = acceptedSheet;
@@ -332,11 +289,9 @@ export default function MatchesScreen() {
     );
   };
 
-  // 바텀시트 - 사물함 QR
   const handleGoLocker = () => {
     setAcceptedSheet(null);
     router.push(ROUTES.SCAN);
-    // TODO: locker_id 활용하여 사물함 안내 화면으로 이동
   };
 
   if (isLoading) {
@@ -352,7 +307,6 @@ export default function MatchesScreen() {
     );
   }
 
-  // FlatList 데이터: 진행 중 + 구분선 + 완료된 것
   const listData: (
     | { type: "match"; data: ItemMatchResultResponse; isCompleted: boolean }
     | { type: "divider" }
@@ -374,7 +328,6 @@ export default function MatchesScreen() {
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
-      {/* 헤더 */}
       <View style={styles.header}>
         <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
           <ChevronLeft size={22} color="#333" />
@@ -501,9 +454,7 @@ export default function MatchesScreen() {
                   ) : null}
                   <View style={styles.finderBox}>
                     <View style={styles.finderAvatar}>
-                      <Text style={styles.finderAvatarText}>
-                        {match.found_nickname?.charAt(0) ?? "?"}
-                      </Text>
+                      <User size={18} color="#aaa" />
                     </View>
                     <View style={{ flex: 1 }}>
                       <Text style={styles.finderName}>
@@ -572,9 +523,7 @@ export default function MatchesScreen() {
                 ) : null}
                 <View style={styles.finderBox}>
                   <View style={styles.finderAvatar}>
-                    <Text style={styles.finderAvatarText}>
-                      {match.found_nickname?.charAt(0) ?? "?"}
-                    </Text>
+                    <User size={18} color="#aaa" />
                   </View>
                   <View>
                     <Text style={styles.finderName}>
@@ -756,7 +705,6 @@ const styles = StyleSheet.create({
     borderRadius: 20,
   },
   scoreBadgeText: { fontSize: 11, fontFamily: fonts.bold, color: "#fff" },
-  // 완료 카드 오버레이
   completedOverlay: {
     position: "absolute",
     top: 0,
@@ -814,12 +762,13 @@ const styles = StyleSheet.create({
   finderAvatar: {
     width: 32,
     height: 32,
-    borderRadius: 16,
+    borderRadius: 10,
     backgroundColor: "#eef2ff",
+    borderWidth: 1.5,
+    borderColor: "#6366f130",
     alignItems: "center",
     justifyContent: "center",
   },
-  finderAvatarText: { fontSize: 13, fontFamily: fonts.bold, color: "#6366f1" },
   finderName: { fontSize: 12, fontFamily: fonts.bold, color: "#333" },
   finderDept: {
     fontSize: 11,
@@ -1007,12 +956,13 @@ const sheetStyles = StyleSheet.create({
   finderAvatar: {
     width: 40,
     height: 40,
-    borderRadius: 20,
+    borderRadius: 12,
     backgroundColor: "#eef2ff",
+    borderWidth: 1.5,
+    borderColor: "#6366f130",
     alignItems: "center",
     justifyContent: "center",
   },
-  finderAvatarText: { fontSize: 16, fontFamily: fonts.bold, color: "#6366f1" },
   finderName: { fontSize: 14, fontFamily: fonts.bold, color: "#111" },
   finderDept: {
     fontSize: 11,

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -1,6 +1,6 @@
 import client from "@/api/client";
 import { fonts } from "@/constants/typography";
-import { ROUTES } from "@/constants/url";
+import { handleNotificationRouting } from "@/utils/notifications/routing";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import {
@@ -29,9 +29,11 @@ type NotificationRecord = {
     | "MATCH_FOUND"
     | "CHAT_MESSAGE"
     | "ITEM_RETURNED"
+    | "ITEM_REPORTED"
     | "THEFT_SUSPECTED"
     | "CCTV_FOUND"
-    | "LOCKER_READY";
+    | "LOCKER_READY"
+    | "QR_SCANNED";
   payload: Record<string, any>;
   read_at: string | null;
   created_at: string;
@@ -42,50 +44,42 @@ const NOTIFICATION_CONFIG = {
     icon: Sparkles,
     label: "매칭 완료",
     message: "분실물과 매칭되었어요! 확인해보세요.",
-    route: ROUTES.MATCHES,
   },
   CHAT_MESSAGE: {
     icon: MessageCircle,
     label: "새 메시지",
     message: "새로운 채팅 메시지가 있어요.",
-    route: ROUTES.CHAT,
   },
   ITEM_RETURNED: {
     icon: CheckCircle,
     label: "반환 완료",
     message: "물건이 성공적으로 반환되었어요.",
-    route: ROUTES.CHAT,
   },
   ITEM_REPORTED: {
     icon: CheckCircle,
     label: "분실물",
     message: "분실물이 있어요. 확인해보세요",
-    route: ROUTES.LOST_ITEM_BOARD,
   },
   THEFT_SUSPECTED: {
     icon: AlertTriangle,
     label: "도난 의심",
     message: "물건에 도난 의심 정황이 감지되었어요.",
-    route: ROUTES.LOST_ITEM_BOARD,
   },
   CCTV_FOUND: {
     icon: AlertTriangle,
     label: "CCTV 발견",
     message: "CCTV에서 내 물건으로 추정되는 영상이 감지되었어요.",
-    route: ROUTES.CCTV_ITEMS,
   },
   LOCKER_READY: {
     icon: Package,
     label: "보관함 준비",
     message: "사물함이 준비되었어요. QR을 스캔해 물건을 꺼내세요.",
-    route: ROUTES.SCAN,
   },
   QR_SCANNED: {
     icon: CheckCircle,
     label: "분실물 발견",
     message: "분실물이 발견되었어요.",
-    route: ROUTES.CHAT,
-  }
+  },
 };
 
 function timeAgo(dateStr: string) {
@@ -149,6 +143,7 @@ export default function NotificationsScreen() {
   };
 
   const handleNotifPress = async (item: NotificationRecord) => {
+    // 읽음 처리
     try {
       if (!item.read_at) {
         await client.patch(`/api/notifications/${item.id}/mark-as-read`);
@@ -162,9 +157,12 @@ export default function NotificationsScreen() {
     } catch (e) {
       console.error("알림 읽음 처리 실패", e);
     }
-    const config = NOTIFICATION_CONFIG[item.type];
-    if (!config) return;
-    router.push(config.route as any);
+
+    // 라우팅 — 푸시 알림이랑 동일한 로직 사용 (type + payload 합쳐서 전달)
+    handleNotificationRouting({
+      type: item.type,
+      ...(item.payload ?? {}),
+    });
   };
 
   const unreadCount = notifications.filter((n) => !n.read_at).length;


### PR DESCRIPTION
#67 

## 작업 내용

### 1. 채팅 목록 카드 리뉴얼 
- **마지막 메시지** 표시
- **안 읽은 개수 뱃지** 
- **상대 시간** 표시 (방금/N분/N시간/어제/N일/M월D일)
- 진행중/반환완료/종료 상태 텍스트 (회색 통일)

### 2. 채팅방 → 게시물 이동
- 채팅방 상단 분실물 배너 클릭 시 해당 게시물로 이동
- `item_id` 기반으로 `lost-item-detail` 라우팅

### 3. 알림 라우팅 개선
- 알림 화면에서 알림 누르면 채팅 목록이 아니라 **해당 채팅방으로 직접 이동**
- 푸시 알림과 동일한 라우팅 로직(`handleNotificationRouting`) 공유
- `NOTIFICATION_CONFIG`에서 `route` 필드 제거 (라우팅 일원화)

### 4. 마이페이지 카드 정리
- AI 매칭 / CCTV 분석 카드의 배경 원 장식 제거
- 하단 의미 없는 점(dot) 제거
- 아이콘 + 제목 + 설명 3요소로 깔끔하게

### 5. 매칭 화면 아바타 통일
- finder 아바타가 닉네임 첫 글자 텍스트였던 것을 → **채팅 목록과 동일한 User 아이콘**으로 변경
- 진행중 카드 / 완료 카드 / 수락 후 바텀시트 3곳 모두 통일

### 6. 로그인 화면 텍스트 수정
- "줍픽" → "줍줍" 
